### PR TITLE
Layout components should be constructed from Box instead of sprinkles

### DIFF
--- a/src/Layout/createLayoutComponents.tsx
+++ b/src/Layout/createLayoutComponents.tsx
@@ -1,13 +1,13 @@
-import { createBentoBox } from "../Box/createBentoBox";
+import { BoxType } from "../Box/createBentoBox";
 import { bentoSprinkles } from "../internal/sprinkles.css";
 import { createInline } from "./createInline";
 import { createStack } from "./createStack";
 import { createColumns } from "./createColumns";
 import { createInset } from "./createInset";
 
-export function createLayoutComponents<AtomsFn extends typeof bentoSprinkles>(sprinkles: AtomsFn) {
-  const Box = createBentoBox(sprinkles);
-
+export function createLayoutComponents<AtomsFn extends typeof bentoSprinkles>(
+  Box: BoxType<AtomsFn>
+) {
   const Inline = createInline(Box);
   const Inset = createInset(Box);
   const Stack = createStack(Box);

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -2,7 +2,8 @@
 
 import { createLayoutComponents } from "../Layout/createLayoutComponents";
 import { bentoSprinkles } from "./sprinkles.css";
+import { Box } from "./Box/Box";
 
 export { bentoSprinkles };
 export * from "./Box/Box";
-export const { Column, Columns, Inline, Inset, Stack } = createLayoutComponents(bentoSprinkles);
+export const { Column, Columns, Inline, Inset, Stack } = createLayoutComponents(Box);

--- a/stories/index.ts
+++ b/stories/index.ts
@@ -5,4 +5,4 @@ export { Placeholder } from "../src";
 
 export * from "../src/";
 export const Box = createBentoBox(sprinkles);
-export const { Stack, Column, Columns, Inline, Inset } = createLayoutComponents(sprinkles);
+export const { Stack, Column, Columns, Inline, Inset } = createLayoutComponents(Box);


### PR DESCRIPTION
# Description
Not sure why we were constructing the layout components from sprinkles, but it feels more natural to build them passing the base building block (Box) instead.
Note: the internal builders for the single layout components were already taking Box as a parameter, so I don't see the reason why `createLayoutComponents` should take the sprinkles and create the Box internally.