### PR TITLE
implement radio with two boxes

### DIFF
--- a/src/RadioGroupField/Radio.css.ts
+++ b/src/RadioGroupField/Radio.css.ts
@@ -1,63 +1,57 @@
+import { style } from "@vanilla-extract/css";
 import { bentoSprinkles } from "../internal";
 import { strictRecipe } from "../util/strictRecipe";
 import { vars } from "../vars.css";
 import { radioOption } from "./RadioGroupField.css";
 
-export const radio = bentoSprinkles({ width: 24, height: 24 });
-
 export const outerRadioCircleRecipe = strictRecipe({
+  base: bentoSprinkles({
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    width: 24,
+    height: 24,
+    borderRadius: "circled",
+  }),
   variants: {
     selected: {
       false: [
-        bentoSprinkles({ fill: "outlineInputEnabled" }),
+        bentoSprinkles({ boxShadow: "outlineInputEnabled" }),
         {
           selectors: {
             [`${radioOption}:hover:not([disabled]) &`]: {
-              fill: vars.outlineColor.outlineInputHover,
+              boxShadow: vars.boxShadow.outlineInputHover,
             },
             [`${radioOption}[disabled] &`]: {
-              fill: vars.outlineColor.outlineInputDisabled,
+              boxShadow: vars.boxShadow.outlineInputDisabled,
             },
           },
         },
       ],
       true: [
-        bentoSprinkles({ fill: "primarySolidEnabledBackground" }),
+        bentoSprinkles({ background: "primarySolidEnabledBackground" }),
         {
           selectors: {
             [`${radioOption}:hover:not([disabled]) &`]: {
-              fill: vars.interactiveBackgroundColor.primarySolidHoverBackground,
+              background: vars.interactiveBackgroundColor.primarySolidHoverBackground,
             },
             [`${radioOption}[disabled] &`]: {
-              fill: vars.interactiveBackgroundColor.disabledSolidBackground,
+              background: vars.interactiveBackgroundColor.disabledSolidBackground,
             },
           },
         },
       ],
     },
     focused: {
-      true: { fill: vars.interactiveBackgroundColor.primarySolidFocusBackground },
+      true: { background: vars.interactiveBackgroundColor.primarySolidFocusBackground },
     },
   },
 });
 
-export const innerRadioCircleRecipe = strictRecipe({
-  base: bentoSprinkles({ fill: "backgroundPrimary" }),
-  variants: {
-    selected: {
-      false: {
-        r: "11",
-      },
-      true: { r: "5" },
-    },
-    focused: {
-      true: {},
-    },
-  },
-  compoundVariants: [
-    {
-      variants: { selected: false, focused: true },
-      style: { r: "10" },
-    },
-  ],
-});
+export const innerRadioCircle = [
+  bentoSprinkles({
+    background: "backgroundPrimary",
+    borderRadius: "circled",
+  }),
+  style({ width: 10, height: 10 }),
+];

--- a/src/RadioGroupField/Radio.tsx
+++ b/src/RadioGroupField/Radio.tsx
@@ -1,13 +1,13 @@
-import { innerRadioCircleRecipe, outerRadioCircleRecipe, radio } from "./Radio.css";
+import { innerRadioCircle, outerRadioCircleRecipe } from "./Radio.css";
+import { Box } from "../internal";
 
 export function Radio({ selected, focused }: { selected: boolean; focused: boolean }) {
   // NOTE(gabro): we can't draw svg strokes "inside" the container, so instead of modelling the radio
   // as a circle with a stroke, we model it as two overlapping circles (one outer larger circle, which
   // we use to draw the radio "border", and one smaller inner circle)
   return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" className={radio}>
-      <circle cx="12" cy="12" r="12" className={outerRadioCircleRecipe({ selected, focused })} />
-      <circle cx="12" cy="12" className={innerRadioCircleRecipe({ selected, focused })} />
-    </svg>
+    <Box className={outerRadioCircleRecipe({ selected, focused })}>
+      {selected && <Box className={innerRadioCircle} />}
+    </Box>
   );
 }


### PR DESCRIPTION
Alternative Radio implementation with two nested boxes instead of an svg.
The advantage is that we can use the input tokens and be consistent with the other inputs.

## Test plan
### Test performed

hover with 1px boxShadow:
![Kapture 2022-03-08 at 14 27 46](https://user-images.githubusercontent.com/925635/157247183-55324fa4-e2c7-4fd1-a6ce-7d06bd43f846.gif)

hover with 2px boxShadow:
![Kapture 2022-03-08 at 14 28 46](https://user-images.githubusercontent.com/925635/157247320-3f4e6449-4f0a-48c1-b899-8aa0d0c5b62e.gif)

