### PR TITLE
Avoid rendering an empty column in Actions

### DIFF
--- a/src/Actions/createActions.tsx
+++ b/src/Actions/createActions.tsx
@@ -72,13 +72,15 @@ export function createActions(
       case "right":
         return (
           <Columns space={config.spaceBetweenButtons} alignY="center" collapseBelow="tablet">
-            <Column width="1/2">
-              {isLoading ? (
-                <InlineLoader message={loadingMessage} />
-              ) : (
-                error && <Banner kind="negative" description={error} />
-              )}
-            </Column>
+            {(isLoading || error) && (
+              <Column width="1/2">
+                {isLoading ? (
+                  <InlineLoader message={loadingMessage} />
+                ) : (
+                  error && <Banner kind="negative" description={error} />
+                )}
+              </Column>
+            )}
             <Inline
               space={config.spaceBetweenButtons}
               align="right"


### PR DESCRIPTION
Otherwise the actions would wrap "unnaturally" when they still have space to grow, e.g.

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/691940/157447432-4e5ac47f-37a1-4888-96d9-1f61e04f8a61.png">
