### PR TITLE
Remove TextColumns type

### DIFF
--- a/src/Table/createTable.tsx
+++ b/src/Table/createTable.tsx
@@ -66,12 +66,6 @@ type SortFn<C extends ReadonlyArray<ColumnType<string, {}, any>>> = (
   b: Row<RowType<C>>
 ) => number;
 
-type TextColumns<C extends readonly any[]> = C extends readonly [infer Head, ...infer Tail]
-  ? Head extends ColumnType<string, {}, LocalizedString>
-    ? [Head, ...TextColumns<Tail>]
-    : TextColumns<Tail>
-  : [];
-
 type SortingProps<C extends ReadonlyArray<ColumnType<string, {}, any>>> =
   | {
       customSorting?: never;
@@ -90,7 +84,7 @@ type SortingProps<C extends ReadonlyArray<ColumnType<string, {}, any>>> =
 type Props<C extends ReadonlyArray<ColumnType<string, {}, any>>> = {
   columns: C;
   data: ReadonlyArray<RowType<C>>;
-  groupBy?: TextColumns<C>[number]["accessor"];
+  groupBy?: C[number]["accessor"];
   noResultsTitle?: LocalizedString;
   noResultsDescription?: LocalizedString;
 } & SortingProps<C>;

--- a/stories/Components/Table.stories.tsx
+++ b/stories/Components/Table.stories.tsx
@@ -260,8 +260,5 @@ export const Grouped = createStory({
     }),
   ] as const,
   data: exampleData,
-  // NOTE(gabro): createStory messes up the type-inference of groupBy, given that this only happens
-  // in the stories I don't think it's too important to fix properly
-  // @ts-expect-error
   groupBy: "group",
 });


### PR DESCRIPTION
The `TextColumns` type is very clever... a bit too much.

Without this change running tsc on a project which uses `Table` would go from ~7s to ~7m 🙀 

This is probably due to heavy type-inference of constants (for the columns) + recursively traversing the resulting tuple.

I'm not sure why this issue appeared after moving `Table` to bento, but it's maybe because the final project now has types in the form of `import(@buildo/bento/...).Table` and that it's potentially slower?