### PR TITLE
re-export MenuTriggerState

### DIFF
--- a/packages/bento-design-system/src/Menu/createMenu.tsx
+++ b/packages/bento-design-system/src/Menu/createMenu.tsx
@@ -100,3 +100,5 @@ export const defaultMenuConfig: MenuConfig = {
   headerPaddingY: 24,
   defaultOffset: 4,
 };
+
+export type { MenuTriggerState };


### PR DESCRIPTION
Let's see if this solves the need to add `@react-stately/menu` to the project's tsconfig and deps