### PR TITLE
export Placement type from @react-types/overlays

### DIFF
--- a/packages/bento-design-system/src/Popover/Popover.tsx
+++ b/packages/bento-design-system/src/Popover/Popover.tsx
@@ -76,3 +76,5 @@ export function Popover({
     </OverlayContainer>
   );
 }
+
+export type { Placement };


### PR DESCRIPTION
It should solve the same issue we had with `@react-stately/menu`