### PR TITLE
Fix feedback background when not defined

### DIFF
--- a/packages/bento-design-system/src/Feedback/createFeedback.tsx
+++ b/packages/bento-design-system/src/Feedback/createFeedback.tsx
@@ -151,7 +151,7 @@ export function createFeedback(Button: FunctionComponent<ButtonProps>, config: F
       size: config.illustrationSize[size],
       style: "color",
     };
-    if (background) {
+    if (background && config.background) {
       // NOTE(gabro): when we have a background, the overall size of the illustration is the one of
       // the background so the background has position relative and the illustration has position absolute.
       return (


### PR DESCRIPTION
When a background for `Feedback` is not defined and the component is called with `background={true}`, this happens:
![screenshot-2022-03-23-10-49-06](https://user-images.githubusercontent.com/26444095/159671868-c53bf72e-493b-4c45-aff0-9e2eb6207084.png)

With this fix, the illustration is rendered correctly above the text:
![screenshot-2022-03-23-10-49-26](https://user-images.githubusercontent.com/26444095/159671974-a5f92e3f-5616-4b04-b7de-96f8a8d411e5.png)

