### PR TITLE
Allow any number as size for illustrations

### DIFF
--- a/packages/bento-design-system/src/Illustrations/IllustrationProps.ts
+++ b/packages/bento-design-system/src/Illustrations/IllustrationProps.ts
@@ -1,5 +1,5 @@
 export type IllustrationProps = {
-  size: 24 | 32 | 40 | 80 | 160;
+  size: 24 | 32 | 40 | 80 | 160 | number;
 } & (
   | {
       style: "color";

--- a/packages/bento-design-system/src/Illustrations/svgIllustrationProps.ts
+++ b/packages/bento-design-system/src/Illustrations/svgIllustrationProps.ts
@@ -22,16 +22,5 @@ function outlineColor(color: (IllustrationProps & { style: "outline" })["color"]
 }
 
 function sizeToDimensions(size: IllustrationProps["size"]): { width: number; height: number } {
-  switch (size) {
-    case 24:
-      return { width: 24, height: 24 };
-    case 32:
-      return { width: 32, height: 32 };
-    case 40:
-      return { width: 40, height: 40 };
-    case 80:
-      return { width: 80, height: 80 };
-    case 160:
-      return { width: 160, height: 160 };
-  }
+  return { width: size, height: size };
 }


### PR DESCRIPTION
### tests performed
✅ this compiles:
<img width="473" alt="Screenshot 2022-03-23 at 11 36 51" src="https://user-images.githubusercontent.com/26444095/159681001-e80fd91e-a3cf-4863-b0ae-29e2abf427a4.png">
