### PR TITLE
loader in Actions no longer takes half of the width

### DIFF
--- a/packages/bento-design-system/src/Actions/createActions.tsx
+++ b/packages/bento-design-system/src/Actions/createActions.tsx
@@ -72,13 +72,14 @@ export function createActions(
       case "right":
         return (
           <Columns space={config.spaceBetweenButtons} alignY="center" collapseBelow="tablet">
-            {(isLoading || error) && (
+            {isLoading && (
+              <Column width="content">
+                <InlineLoader message={loadingMessage} />
+              </Column>
+            )}
+            {error && !isLoading && (
               <Column width="1/2">
-                {isLoading ? (
-                  <InlineLoader message={loadingMessage} />
-                ) : (
-                  error && <Banner kind="negative" description={error} />
-                )}
+                <Banner kind="negative" description={error} />
               </Column>
             )}
             <Inline
@@ -103,15 +104,18 @@ export function createActions(
             <Inline space={config.spaceBetweenButtons} alignY="center" collapseBelow="tablet">
               {buttons}
             </Inline>
-            <Column width="1/2">
-              {isLoading ? (
+            {isLoading && (
+              <Column width="content">
                 <Inline space={0} align="right" alignY="center">
                   <InlineLoader message={loadingMessage} />
                 </Inline>
-              ) : (
-                <Column>{error && <Banner kind="negative" description={error} />}</Column>
-              )}
-            </Column>
+              </Column>
+            )}
+            {error && !isLoading && (
+              <Column width="1/2">
+                <Banner kind="negative" description={error} />
+              </Column>
+            )}
           </Columns>
         );
       case "spaceBetween":

--- a/packages/storybook/stories/Components/Modal.stories.tsx
+++ b/packages/storybook/stories/Components/Modal.stories.tsx
@@ -87,7 +87,7 @@ export const Destructive = createStory({
 export const WithAsyncPrimaryAction = createStory({
   children: [<Placeholder />],
   primaryAction: {
-    label: formatMessage("Create"),
+    label: formatMessage("Create new item"),
     onPress: () =>
       new Promise((resolve) => {
         setTimeout(() => {


### PR DESCRIPTION
### Before
<img width="602" alt="image" src="https://user-images.githubusercontent.com/925635/160592357-f689e369-def5-49bf-95de-63181ff5bb4f.png">

### After
<img width="593" alt="image" src="https://user-images.githubusercontent.com/925635/160592528-5f0cc712-63e0-42e3-bb15-a73d7bdb9895.png">
