### PR TITLE
Move linkConfig parameter in createBentoProvider

### DIFF
--- a/packages/bento-design-system/src/BentoProvider.tsx
+++ b/packages/bento-design-system/src/BentoProvider.tsx
@@ -34,13 +34,15 @@ type Props = {
   linkConfig?: LinkConfig;
 } & DefaultMessages;
 
-export function createBentoProvider(ToastProvider: FunctionComponent<ToastProviderProps>) {
+export function createBentoProvider(
+  ToastProvider: FunctionComponent<ToastProviderProps>,
+  linkConfig?: LinkConfig
+) {
   return function BentoProvider({
     children,
     toastDismissAfterMs = 5000,
     defaultMessages,
     linkComponent,
-    linkConfig,
   }: Props) {
     const linkComponentFromContext = useContext(LinkComponentContext);
 

--- a/packages/bento-design-system/src/createBentoComponents.ts
+++ b/packages/bento-design-system/src/createBentoComponents.ts
@@ -93,7 +93,8 @@ export function createBentoComponents<
     Banner,
   });
 
-  const Link = createLink(merge(defaultConfigs.link, config.link ?? {}));
+  const linkConfig = merge(defaultConfigs.link, config.link ?? {});
+  const Link = createLink(linkConfig);
 
   const Breadcrumb = createBreadcrumb(merge(defaultConfigs.breadcrumb, config.breadcrumb ?? {}), {
     Link,
@@ -187,7 +188,7 @@ export function createBentoComponents<
     IconButton,
   });
 
-  const DesignSystemProvider = createBentoProvider(ToastProvider);
+  const DesignSystemProvider = createBentoProvider(ToastProvider, linkConfig);
 
   const icons = {
     IconIdea,


### PR DESCRIPTION
Currently, `linkConfig` needs to be defined once when calling `createBentoComponents` and again when using `DesignSystemProvider`. This PR changes that, so that `DesignSystemProvider` automatically uses the `linkConfig` passed to `createBentoComponents`.