### PR TITLE
Allow children in Link

### DIFF
--- a/packages/bento-design-system/src/Link/Link.tsx
+++ b/packages/bento-design-system/src/Link/Link.tsx
@@ -1,6 +1,6 @@
 import { AnchorHTMLAttributes, useRef } from "react";
 import { useLinkComponent } from "../util/link";
-import { LocalizedString } from "..";
+import { Children, LocalizedString } from "..";
 import { Box } from "../internal";
 import { useLink } from "@react-aria/link";
 import * as resetStyles from "../reset.css";
@@ -8,16 +8,26 @@ import { linkRecipe } from "./Link.css";
 import { extendedHitAreaRecipe } from "../util/extendedHitArea.css";
 
 type Props = {
-  label: LocalizedString;
   isDisabled?: boolean;
   active?: boolean;
   kind?: "default" | "inverse";
-} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "color">;
+} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "color"> &
+  (
+    | {
+        label: LocalizedString;
+        children?: never;
+      }
+    | {
+        label?: never;
+        children: Children;
+      }
+  );
 
 export function Link({
   href,
   isDisabled,
   label,
+  children,
   active = false,
   kind = "default",
   ...props
@@ -51,7 +61,7 @@ export function Link({
       disabled={isDisabled}
       display="inline-block"
     >
-      {label}
+      {label ?? children}
     </Box>
   );
 }

--- a/packages/storybook/stories/Components/Link.stories.tsx
+++ b/packages/storybook/stories/Components/Link.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from "@storybook/addon-actions";
 import React from "react";
-import { Body, Label, Link } from "..";
+import { Body, Box, Label, Link } from "..";
 import { createComponentStories, formatMessage } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
@@ -70,3 +70,19 @@ InLabel.decorators = [
     </Label>
   ),
 ];
+
+export const ComplexChildren = createStory({
+  href: "http://www.example.com",
+  target: "_blank",
+  label: undefined,
+  children: (
+    <Box
+      background={"backgroundPositive"}
+      padding={40}
+      borderRadius={16}
+      boxShadow="outlinePositive"
+    >
+      <Body size="large">{formatMessage("The entire box is a link!")}</Body>
+    </Box>
+  ),
+});


### PR DESCRIPTION
Two reasons:
- it's easier to plug into libraries like react-i18next
- it allows having a link "around" complex components