### PR TITLE
Docs components

### DIFF
--- a/packages/bento-design-system/src/Button/createButton.tsx
+++ b/packages/bento-design-system/src/Button/createButton.tsx
@@ -20,6 +20,9 @@ type Props = {
   icon?: (props: IconProps) => JSX.Element;
 } & AriaButtonProps<"button">;
 
+/**
+ * A button
+ */
 export function createButton(config: ButtonConfig) {
   return function Button(props: Props) {
     const ref = useRef<HTMLButtonElement>(null);

--- a/packages/website/docs/Components/Actions.mdx
+++ b/packages/website/docs/Components/Actions.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Actions"
+  constructorName="createActions"
+  examplePath="Components/Actions"
+  zeroheightSlug="76d584-actions"
+  storybookStoryId="components-actions"
+/>

--- a/packages/website/docs/Components/AreaLoader.mdx
+++ b/packages/website/docs/Components/AreaLoader.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="AreaLoader"
+  constructorName="createAreaLoader"
+  examplePath="Components/AreaLoader"
+  zeroheightSlug="80fd92-loader"
+  storybookStoryId="components-area-loader"
+/>

--- a/packages/website/docs/Components/Avatar.mdx
+++ b/packages/website/docs/Components/Avatar.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Avatar"
+  constructorName="createAvatar"
+  examplePath="Components/Avatar"
+  zeroheightSlug="12de24-avatar"
+  storybookStoryId="components-avatar"
+/>

--- a/packages/website/docs/Components/Banner.mdx
+++ b/packages/website/docs/Components/Banner.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Banner"
+  constructorName="createBanner"
+  examplePath="Components/Banner"
+  zeroheightSlug="367058-banner"
+  storybookStoryId="components-banner"
+/>

--- a/packages/website/docs/Components/Breadcrumb.mdx
+++ b/packages/website/docs/Components/Breadcrumb.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Breadcrumb"
+  constructorName="createBreadcrumb"
+  examplePath="Components/Breadcrumb"
+  zeroheightSlug="859afc-breadcrumb"
+  storybookStoryId="components-breadcrumb"
+/>

--- a/packages/website/docs/Components/Button.mdx
+++ b/packages/website/docs/Components/Button.mdx
@@ -3,12 +3,8 @@ import { Canvas } from "@site/src/components/Canvas";
 
 <ComponentDoc
   name="Button"
-  constructorName="createButtons"
+  constructorName="createButton"
   examplePath="Components/Button"
   zeroheightSlug="743d02-button"
   storybookStoryId="components-button"
->
-
-`Button` is a thing to click on things.
-
-</ComponentDoc>
+/>

--- a/packages/website/docs/Components/Card.mdx
+++ b/packages/website/docs/Components/Card.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Card"
+  constructorName="createCard"
+  examplePath="Components/Card"
+  zeroheightSlug="686ab3-card"
+  storybookStoryId="components-card"
+/>

--- a/packages/website/docs/Components/CheckboxField.mdx
+++ b/packages/website/docs/Components/CheckboxField.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="CheckboxField"
+  constructorName="createCheckboxField"
+  examplePath="Components/CheckboxField"
+  zeroheightSlug="260f01-input"
+  storybookStoryId="components-checkbox-field"
+/>

--- a/packages/website/docs/Components/Chip.mdx
+++ b/packages/website/docs/Components/Chip.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Chip"
+  constructorName="createChip"
+  examplePath="Components/Chip"
+  zeroheightSlug="93cea1-chip"
+  storybookStoryId="components-chip"
+/>

--- a/packages/website/docs/Components/Disclosure.mdx
+++ b/packages/website/docs/Components/Disclosure.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Disclosure"
+  constructorName="createDisclosure"
+  examplePath="Components/Disclosure"
+  zeroheightSlug="098a65-disclosure"
+  storybookStoryId="components-disclosure"
+/>

--- a/packages/website/docs/Components/Divider.mdx
+++ b/packages/website/docs/Components/Divider.mdx
@@ -1,0 +1,9 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Divider"
+  constructorName="createDivider"
+  examplePath="Components/Divider"
+  zeroheightSlug="48e9b1-divider"
+/>

--- a/packages/website/docs/Components/Feedback.mdx
+++ b/packages/website/docs/Components/Feedback.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Feedback"
+  constructorName="createFeedback"
+  examplePath="Components/Feedback"
+  zeroheightSlug="64a5e3-feedback"
+  storybookStoryId="components-feedback"
+/>

--- a/packages/website/docs/Components/Form.mdx
+++ b/packages/website/docs/Components/Form.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Form"
+  constructorName="createForm"
+  examplePath="Components/Form"
+  zeroheightSlug="231049-form"
+  storybookStoryId="components-form"
+/>

--- a/packages/website/docs/Components/InlineLoader.mdx
+++ b/packages/website/docs/Components/InlineLoader.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="InlineLoader"
+  constructorName="createInlineLoader"
+  examplePath="Components/InlineLoader"
+  zeroheightSlug="80fd92-loader"
+  storybookStoryId="components-inline-loader"
+/>

--- a/packages/website/docs/Components/List.mdx
+++ b/packages/website/docs/Components/List.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="List"
+  constructorName="createList"
+  examplePath="Components/List"
+  zeroheightSlug="06aec9-list"
+  storybookStoryId="components-list"
+/>

--- a/packages/website/docs/Components/Menu.mdx
+++ b/packages/website/docs/Components/Menu.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Menu"
+  constructorName="createMenu"
+  examplePath="Components/Menu"
+  zeroheightSlug="61f189-menu"
+  storybookStoryId="components-menu"
+/>

--- a/packages/website/docs/Components/Modal.mdx
+++ b/packages/website/docs/Components/Modal.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Modal"
+  constructorName="createModal"
+  examplePath="Components/Modal"
+  zeroheightSlug="238cdb-modal"
+  storybookStoryId="components-modal"
+/>

--- a/packages/website/docs/Components/Navigation.mdx
+++ b/packages/website/docs/Components/Navigation.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Navigation"
+  constructorName="createNavigation"
+  examplePath="Components/Navigation"
+  zeroheightSlug="5115d6-navigation"
+  storybookStoryId="components-navigation"
+/>

--- a/packages/website/docs/Components/ProgressBar.mdx
+++ b/packages/website/docs/Components/ProgressBar.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="ProgressBar"
+  constructorName="createProgressBar"
+  examplePath="Components/ProgressBar"
+  zeroheightSlug="234607-progress-bar"
+  storybookStoryId="components-progress-bar"
+/>

--- a/packages/website/docs/Components/RadioGroupField.mdx
+++ b/packages/website/docs/Components/RadioGroupField.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="RadioGroupField"
+  constructorName="createRadioGroupField"
+  examplePath="Components/RadioGroupField"
+  zeroheightSlug="260f01-input"
+  storybookStoryId="components-radio-group-field"
+/>

--- a/packages/website/docs/Components/SearchBar.mdx
+++ b/packages/website/docs/Components/SearchBar.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="SearchBar"
+  constructorName="createSearchBar"
+  examplePath="Components/SearchBar"
+  zeroheightSlug="07818a-search-bar"
+  storybookStoryId="components-search-bar"
+/>

--- a/packages/website/docs/Components/SliderField.mdx
+++ b/packages/website/docs/Components/SliderField.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="SliderField"
+  constructorName="createSliderField"
+  examplePath="Components/SliderField"
+  zeroheightSlug="54de03-slider"
+  storybookStoryId="components-slider-field"
+/>

--- a/packages/website/docs/Components/Stepper.mdx
+++ b/packages/website/docs/Components/Stepper.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Stepper"
+  constructorName="createStepper"
+  examplePath="Components/Stepper"
+  zeroheightSlug="8728a9-stepper"
+  storybookStoryId="components-stepper"
+/>

--- a/packages/website/docs/Components/Switch.mdx
+++ b/packages/website/docs/Components/Switch.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Switch"
+  constructorName="createSwitch"
+  examplePath="Components/Switch"
+  zeroheightSlug="022a76-selection-controls"
+  storybookStoryId="components-switch"
+/>

--- a/packages/website/docs/Components/Table.mdx
+++ b/packages/website/docs/Components/Table.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Table"
+  constructorName="createTable"
+  examplePath="Components/Table"
+  zeroheightSlug="156487-table"
+  storybookStoryId="components-table"
+/>

--- a/packages/website/docs/Components/Tabs.mdx
+++ b/packages/website/docs/Components/Tabs.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="FolderTabs"
+  constructorName="createTabs"
+  examplePath="Components/Tabs"
+  zeroheightSlug="290569-tabs"
+  storybookStoryId="components-tabs"
+/>

--- a/packages/website/docs/Components/TextField.mdx
+++ b/packages/website/docs/Components/TextField.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="TextField"
+  constructorName="createTextField"
+  examplePath="Components/TextField"
+  zeroheightSlug="260f01-input"
+  storybookStoryId="components-text-field"
+/>

--- a/packages/website/docs/Components/Toast.mdx
+++ b/packages/website/docs/Components/Toast.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Toast"
+  constructorName="createToast"
+  examplePath="Components/Toast"
+  zeroheightSlug="223d3a-toast"
+  storybookStoryId="components-toast"
+/>

--- a/packages/website/docs/Components/Tooltip.mdx
+++ b/packages/website/docs/Components/Tooltip.mdx
@@ -1,0 +1,10 @@
+import ComponentDoc from "./_ComponentDoc.mdx";
+import { Canvas } from "@site/src/components/Canvas";
+
+<ComponentDoc
+  name="Tooltip"
+  constructorName="createTooltip"
+  examplePath="Components/Tooltip"
+  zeroheightSlug="00d033-tooltip"
+  storybookStoryId="components-tooltip"
+/>

--- a/packages/website/docs/Components/_ComponentDoc.mdx
+++ b/packages/website/docs/Components/_ComponentDoc.mdx
@@ -3,14 +3,15 @@ import { PropTable } from "@site/src/components/PropTable";
 import { ExternalLinkCard } from "@site/src/components/ExternalLinkCard";
 import { ComponentHeader } from "@site/src/components/ComponentHeader";
 
-<>{props.constructorName && <ComponentHeader name={props.constructorName} />}</>
-<br />
-
 <div style={{ display: "flex", gap: 24 }}>
   {props.name && <ExternalLinkCard type="github" componentName={props.name} />}
   {props.zeroheightSlug && <ExternalLinkCard type="zeroheight" slug={props.zeroheightSlug} />}
   {props.storybookStoryId && <ExternalLinkCard type="storybook" storyId={props.storybookStoryId} />}
 </div>
+
+<br />
+<>{props.constructorName && <ComponentHeader name={props.constructorName} />}</>
+<br />
 
 ### Example
 

--- a/packages/website/docs/Components/_ComponentDoc.mdx
+++ b/packages/website/docs/Components/_ComponentDoc.mdx
@@ -1,8 +1,10 @@
 import { Canvas } from "@site/src/components/Canvas";
 import { PropTable } from "@site/src/components/PropTable";
 import { ExternalLinkCard } from "@site/src/components/ExternalLinkCard";
+import { ComponentHeader } from "@site/src/components/ComponentHeader";
 
-<>{props.children}</>
+<>{props.constructorName && <ComponentHeader name={props.constructorName} />}</>
+<br />
 
 <div style={{ display: "flex", gap: 24 }}>
   {props.name && <ExternalLinkCard type="github" componentName={props.name} />}

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -50,7 +50,7 @@ const config = {
     [
       "docusaurus-plugin-react-docgen-typescript",
       {
-        src: ["../bento-design-system/src/**.{ts,tsx}", "../storybook/stories/index.tsx"],
+        src: ["../bento-design-system/src/**/**.{ts,tsx}", "../storybook/stories/index.tsx"],
         global: true,
         parserOptions: {
           propFilter: (prop) => {

--- a/packages/website/src/components/ComponentHeader.tsx
+++ b/packages/website/src/components/ComponentHeader.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+import useGlobalData from "@docusaurus/useGlobalData";
+
+export const ComponentHeader = ({ name }) => {
+  const description = (
+    useGlobalData()["docusaurus-plugin-react-docgen-typescript"].default as any
+  ).find((x) => x.displayName === name)?.description;
+
+  if (description) {
+    return description;
+  } else return null;
+};

--- a/packages/website/src/components/PropTable.tsx
+++ b/packages/website/src/components/PropTable.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import useGlobalData from "@docusaurus/useGlobalData";
 
 export const PropTable = ({ name }) => {
-  console.log(useGlobalData()["docusaurus-plugin-react-docgen-typescript"].default as any);
   const props = (useGlobalData()["docusaurus-plugin-react-docgen-typescript"].default as any).find(
     (x) => x.displayName === name
   )?.props;

--- a/packages/website/src/components/PropTable.tsx
+++ b/packages/website/src/components/PropTable.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import useGlobalData from "@docusaurus/useGlobalData";
 
 export const PropTable = ({ name }) => {
+  console.log(useGlobalData()["docusaurus-plugin-react-docgen-typescript"].default as any);
   const props = (useGlobalData()["docusaurus-plugin-react-docgen-typescript"].default as any).find(
     (x) => x.displayName === name
   )?.props;


### PR DESCRIPTION
This PR just adds an .mdx file for every Bento component, without caring too much about the content. I didn't implement examples or checked the generated configs/props yet. I just checked the links to github/storybook/zeroheight.

We have an issue with create functions taking dependency components, which are not recognized as react components, thus ignored by the docgen. Also, for at least one component, the create function doesn't have a config, so the docgen is taking the list of dependency components as config keys.