### PR TITLE
#4972850: Slider - add configurations for thumb and trail sizes

### DIFF
--- a/packages/bento-design-system/src/Slider/Config.ts
+++ b/packages/bento-design-system/src/Slider/Config.ts
@@ -11,4 +11,5 @@ export type SliderConfig = {
   thumbWidth: NonNullable<Exclude<BentoSprinkles["width"], "full">>;
   thumbHeight: NonNullable<Exclude<BentoSprinkles["height"], "full">>;
   thumbRadius: BentoSprinkles["borderRadius"];
+  thumbInternalSpacing: BentoSprinkles["gap"];
 };

--- a/packages/bento-design-system/src/Slider/Config.ts
+++ b/packages/bento-design-system/src/Slider/Config.ts
@@ -7,5 +7,8 @@ export type SliderConfig = {
   internalSpacing: BentoSprinkles["gap"];
   trailColor: BentoSprinkles["color"];
   trailRadius: BentoSprinkles["borderRadius"];
+  trailHeight: number;
+  thumbWidth: NonNullable<Exclude<BentoSprinkles["width"], "full">>;
+  thumbHeight: NonNullable<Exclude<BentoSprinkles["height"], "full">>;
   thumbRadius: BentoSprinkles["borderRadius"];
 };

--- a/packages/bento-design-system/src/Slider/Slider.css.ts
+++ b/packages/bento-design-system/src/Slider/Slider.css.ts
@@ -3,10 +3,6 @@ import { bentoSprinkles } from "../internal";
 import { strictRecipe } from "../util/strictRecipe";
 import { vars } from "../vars.css";
 
-const trackContainerHeight = 24;
-const trackHeight = 8;
-const trackOffsetY = (trackContainerHeight - trackHeight) / 2;
-
 export const slider = style({
   // NOTE(gabro): not super pretty, but this is because the thumbs as positioned absolutely,
   // so their labels don't contribute to the vertical space, causing them to overlap with elements
@@ -15,41 +11,26 @@ export const slider = style({
   paddingBottom: `calc(${vars.lineHeight.bodyMedium} + ${vars.space[8]})`,
 });
 
-export const trackContainer = style([
-  {
-    height: trackContainerHeight,
+export const trackContainer = bentoSprinkles({
+  position: "relative",
+  width: "full",
+});
+
+export const trackActive = bentoSprinkles({
+  color: {
+    disabled: "foregroundDisabled",
   },
-  bentoSprinkles({
-    position: "relative",
-    width: "full",
-  }),
-]);
+  position: "absolute",
+});
 
-export const trackActive = style([
-  { top: trackOffsetY },
-  bentoSprinkles({
-    height: 8,
-    color: {
-      disabled: "foregroundDisabled",
-    },
-    position: "absolute",
-  }),
-]);
-
-export const trackInactive = style([
-  { top: trackOffsetY },
-  bentoSprinkles({
-    height: 8,
-    position: "absolute",
-    background: "backgroundOverlay",
-    width: "full",
-  }),
-]);
+export const trackInactive = bentoSprinkles({
+  position: "absolute",
+  background: "backgroundOverlay",
+  width: "full",
+});
 
 export const thumbRecipe = strictRecipe({
   base: bentoSprinkles({
-    width: 24,
-    height: 24,
     cursor: { default: "pointer", disabled: "notAllowed" },
     background: "backgroundSecondary",
     boxShadow: {

--- a/packages/bento-design-system/src/Slider/createSlider.tsx
+++ b/packages/bento-design-system/src/Slider/createSlider.tsx
@@ -120,7 +120,7 @@ export function createSlider(config: SliderConfig) {
           left: `${state.getThumbPercent(index) * 100}%`,
         }}
       >
-        <Stack space={8} align="center">
+        <Stack space={config.thumbInternalSpacing} align="center">
           <Box
             className={thumbRecipe({
               isFocused: isFocusVisible,

--- a/packages/bento-design-system/src/Slider/createSlider.tsx
+++ b/packages/bento-design-system/src/Slider/createSlider.tsx
@@ -112,6 +112,14 @@ export function createSlider(config: SliderConfig) {
     );
     const { focusProps, isFocusVisible } = useFocusRing();
 
+    const output = (
+      <Box as="output" {...props.outputProps} color={undefined}>
+        <Label size="large" color={props.disabled ? "disabled" : undefined}>
+          {state.getThumbValueLabel(props.index)}
+        </Label>
+      </Box>
+    );
+
     return (
       <Box
         position="absolute"
@@ -136,13 +144,7 @@ export function createSlider(config: SliderConfig) {
               <input ref={inputRef} {...mergeProps(inputProps, focusProps)} />
             </VisuallyHidden>
           </Box>
-          {props.showValue && (
-            <Box as="output" {...props.outputProps} color={undefined}>
-              <Label size="large" color={props.disabled ? "disabled" : undefined}>
-                {state.getThumbValueLabel(props.index)}
-              </Label>
-            </Box>
-          )}
+          {props.showValue ? output : <VisuallyHidden>{output}</VisuallyHidden>}
         </Stack>
       </Box>
     );

--- a/packages/bento-design-system/src/Slider/createSlider.tsx
+++ b/packages/bento-design-system/src/Slider/createSlider.tsx
@@ -32,6 +32,7 @@ export function createSlider(config: SliderConfig) {
           </Column>
           <Box
             className={trackContainer}
+            height={config.thumbHeight}
             {...props.trackProps}
             ref={props.trackRef}
             color={undefined}
@@ -40,6 +41,10 @@ export function createSlider(config: SliderConfig) {
               className={trackInactive}
               disabled={props.disabled}
               borderRadius={config.trailRadius}
+              style={{
+                height: config.trailHeight,
+                top: (config.thumbHeight - config.trailHeight) / 2,
+              }}
             />
             <Box
               className={trackActive}
@@ -48,6 +53,8 @@ export function createSlider(config: SliderConfig) {
               disabled={props.disabled}
               borderRadius={config.trailRadius}
               style={{
+                height: config.trailHeight,
+                top: (config.thumbHeight - config.trailHeight) / 2,
                 left: props.type === "single" ? 0 : `${props.state.getThumbPercent(0) * 100}%`,
                 width:
                   props.type === "single"
@@ -118,6 +125,8 @@ export function createSlider(config: SliderConfig) {
             color={undefined}
             disabled={props.disabled}
             borderRadius={config.thumbRadius}
+            width={config.thumbWidth}
+            height={config.thumbHeight}
           >
             <VisuallyHidden>
               <input ref={inputRef} {...mergeProps(inputProps, focusProps)} />

--- a/packages/bento-design-system/src/Slider/createSlider.tsx
+++ b/packages/bento-design-system/src/Slider/createSlider.tsx
@@ -18,6 +18,7 @@ type Props = {
   trackProps: React.HTMLAttributes<HTMLElement>;
   outputProps: OutputHTMLAttributes<HTMLOutputElement>;
   numberFormatter: Intl.NumberFormat;
+  hideThumbValue?: boolean;
 };
 
 export function createSlider(config: SliderConfig) {
@@ -68,6 +69,7 @@ export function createSlider(config: SliderConfig) {
               trackRef={props.trackRef}
               outputProps={props.outputProps}
               disabled={props.disabled}
+              showValue={!props.hideThumbValue}
             />
             {props.type === "double" && (
               <Thumb
@@ -76,6 +78,7 @@ export function createSlider(config: SliderConfig) {
                 trackRef={props.trackRef}
                 outputProps={props.outputProps}
                 disabled={props.disabled}
+                showValue={!props.hideThumbValue}
               />
             )}
           </Box>
@@ -97,6 +100,7 @@ export function createSlider(config: SliderConfig) {
     index: number;
     outputProps: OutputHTMLAttributes<HTMLOutputElement>;
     disabled?: boolean;
+    showValue: boolean;
   };
 
   function Thumb(props: ThumbProps) {
@@ -132,11 +136,13 @@ export function createSlider(config: SliderConfig) {
               <input ref={inputRef} {...mergeProps(inputProps, focusProps)} />
             </VisuallyHidden>
           </Box>
-          <Box as="output" {...props.outputProps} color={undefined}>
-            <Label size="large" color={props.disabled ? "disabled" : undefined}>
-              {state.getThumbValueLabel(props.index)}
-            </Label>
-          </Box>
+          {props.showValue && (
+            <Box as="output" {...props.outputProps} color={undefined}>
+              <Label size="large" color={props.disabled ? "disabled" : undefined}>
+                {state.getThumbValueLabel(props.index)}
+              </Label>
+            </Box>
+          )}
         </Stack>
       </Box>
     );

--- a/packages/bento-design-system/src/SliderField/createSliderField.tsx
+++ b/packages/bento-design-system/src/SliderField/createSliderField.tsx
@@ -20,6 +20,7 @@ type Props = (
   step?: number;
   dragStep?: number;
   autoFocus?: boolean;
+  hideThumbLabel?: boolean;
 } & FormatProps;
 
 function roundToStep(value: number, step: number) {

--- a/packages/bento-design-system/src/SliderField/createSliderField.tsx
+++ b/packages/bento-design-system/src/SliderField/createSliderField.tsx
@@ -20,7 +20,7 @@ type Props = (
   step?: number;
   dragStep?: number;
   autoFocus?: boolean;
-  hideThumbLabel?: boolean;
+  hideThumbValue?: boolean;
 } & FormatProps;
 
 function roundToStep(value: number, step: number) {

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -488,6 +488,9 @@ export const slider: SliderConfig = {
   internalSpacing: 24,
   trailColor: "brandPrimary",
   trailRadius: "circledX",
+  trailHeight: 8,
+  thumbWidth: 24,
+  thumbHeight: 24,
   thumbRadius: 8,
 };
 

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -492,6 +492,7 @@ export const slider: SliderConfig = {
   thumbWidth: 24,
   thumbHeight: 24,
   thumbRadius: 8,
+  thumbInternalSpacing: 8,
 };
 
 export const stepper: StepperConfig = {

--- a/packages/storybook/stories/Components/SliderField.stories.tsx
+++ b/packages/storybook/stories/Components/SliderField.stories.tsx
@@ -60,3 +60,8 @@ export const CustomDragStep = createControlledStory(28, {
   step: 2,
   dragStep: 9,
 });
+
+export const WithoutThumbValue = createControlledStory([30, 80], {
+  type: "double",
+  hideThumbValue: true,
+});


### PR DESCRIPTION
Closes [#4972850](https://buildo.kaiten.io/4972850)

## Test Plan

### tests performed
Tested with:
thumbWidth=8
thumbHeight=8
thumbInternalSpacing=4
trailHeight=2

<img width="554" alt="image" src="https://user-images.githubusercontent.com/925635/166678902-52b31ea6-2203-4d7b-90fc-ddf278d412c9.png">
