### PR TITLE
Fix a weird glitch with background: cover on iOS

### DIFF
--- a/packages/website/src/pages/index.module.css
+++ b/packages/website/src/pages/index.module.css
@@ -10,6 +10,10 @@
   overflow: hidden;
   background-image: url(/img/CoverLight.svg);
   background-size: cover;
+  /* NOTE(gabro): this is to fix a 1px offset to the left that appears on iOS
+   * The fix is loosely based on https: //stackoverflow.com/a/21456799/846273
+   */
+  background-attachment: local;
 }
 
 html[data-theme="dark"] .heroBanner {


### PR DESCRIPTION
Before:

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/691940/166910673-c483b2f2-7012-4dcd-b419-f88929b0800a.png" />
	<td><img src="https://user-images.githubusercontent.com/691940/166910921-cfd8a052-ee0f-4280-a623-867d45927acd.png" />

</table>
