### PR TITLE
#5097621: DateField - date picker grows when there are too many shortcuts

### DIFF
--- a/packages/bento-design-system/src/DateField/Calendar.tsx
+++ b/packages/bento-design-system/src/DateField/Calendar.tsx
@@ -121,11 +121,13 @@ export function createCalendar(
               if (typeof day === "object") {
                 return <Day key={day.dayLabel} {...props} date={day.date} label={day.dayLabel} />;
               } else {
-                return <Box key={`empty-${index}`} width={40} height={40} />;
+                return (
+                  <Box key={`empty-${index}`} width={config.dayWidth} height={config.dayHeight} />
+                );
               }
             })}
           </Tiles>
-          {props.shortcuts}
+          <Box style={{ maxWidth: config.dayWidth * 7 }}>{props.shortcuts}</Box>
         </Stack>
       </Box>
     );

--- a/packages/bento-design-system/src/DateField/Config.ts
+++ b/packages/bento-design-system/src/DateField/Config.ts
@@ -3,10 +3,11 @@ import { BentoSprinkles } from "../internal";
 import { BodyProps } from "../Typography/Body/Body";
 import { LabelProps } from "../Typography/Label/Label";
 import { Children } from "../util/Children";
+import { vars } from "../vars.css";
 
 export type DateFieldConfig = {
-  radius: BentoSprinkles["borderRadius"];
-  padding: BentoSprinkles["padding"];
+  radius: NonNullable<BentoSprinkles["borderRadius"]>;
+  padding: NonNullable<BentoSprinkles["padding"]>;
   elevation: "none" | "small" | "medium" | "large";
   monthYearLabelSize: LabelProps["size"];
   dayOfWeekLabelSize: LabelProps["size"];
@@ -16,8 +17,8 @@ export type DateFieldConfig = {
     open: (props: IconProps) => Children;
     close: (props: IconProps) => Children;
   };
-  dayWidth: BentoSprinkles["width"];
-  dayHeight: BentoSprinkles["height"];
-  dayRadius: BentoSprinkles["borderRadius"];
+  dayWidth: keyof typeof vars.space;
+  dayHeight: keyof typeof vars.space;
+  dayRadius: NonNullable<BentoSprinkles["borderRadius"]>;
   daySize: BodyProps["size"];
 };


### PR DESCRIPTION
Closes [#5097621](https://buildo.flowfast.io/5097621)

## Test Plan

### tests performed

<img width="411" alt="image" src="https://user-images.githubusercontent.com/925635/170968831-365a499e-abed-4157-9fae-b2c8c70f096b.png">
<img width="402" alt="image" src="https://user-images.githubusercontent.com/925635/170968935-9420e15e-a67c-414d-ad2d-ee7fcb9d9937.png">
