### PR TITLE
Use border instead of outline for Card, Menu, and Toast

### DIFF
--- a/packages/bento-design-system/src/Card/Card.css.ts
+++ b/packages/bento-design-system/src/Card/Card.css.ts
@@ -4,9 +4,9 @@ import { strictRecipe } from "../util/strictRecipe";
 export const cardRecipe = strictRecipe({
   base: bentoSprinkles({
     background: "backgroundPrimary",
-    outlineColor: "outlineContainer",
-    outlineStyle: "solid",
-    outlineWidth: 1,
+    borderColor: "outlineContainer",
+    borderStyle: "solid",
+    borderWidth: 1,
     overflow: "hidden",
   }),
   variants: {

--- a/packages/bento-design-system/src/Menu/Menu.css.ts
+++ b/packages/bento-design-system/src/Menu/Menu.css.ts
@@ -11,9 +11,9 @@ export const menuRecipe = strictRecipe({
       },
       bentoSprinkles({
         background: "backgroundPrimary",
-        outlineStyle: "solid",
-        outlineColor: "outlineContainer",
-        outlineWidth: 1,
+        borderStyle: "solid",
+        borderColor: "outlineContainer",
+        borderWidth: 1,
         overflow: "hidden",
       }),
     ]),

--- a/packages/bento-design-system/src/Toast/Toast.css.ts
+++ b/packages/bento-design-system/src/Toast/Toast.css.ts
@@ -17,8 +17,8 @@ export const toastRecipe = strictRecipe({
     },
     hasOutline: {
       true: {
-        outlineWidth: 1,
-        outlineStyle: "solid",
+        borderWidth: 1,
+        borderStyle: "solid",
       },
     },
     elevation: {
@@ -34,35 +34,35 @@ export const toastRecipe = strictRecipe({
         kind: "informative",
         hasOutline: true,
       },
-      style: bentoSprinkles({ outlineColor: "outlineInformative" }),
+      style: bentoSprinkles({ borderColor: "outlineInformative" }),
     },
     {
       variants: {
         kind: "positive",
         hasOutline: true,
       },
-      style: bentoSprinkles({ outlineColor: "outlinePositive" }),
+      style: bentoSprinkles({ borderColor: "outlinePositive" }),
     },
     {
       variants: {
         kind: "warning",
         hasOutline: true,
       },
-      style: bentoSprinkles({ outlineColor: "outlineWarning" }),
+      style: bentoSprinkles({ borderColor: "outlineWarning" }),
     },
     {
       variants: {
         kind: "negative",
         hasOutline: true,
       },
-      style: bentoSprinkles({ outlineColor: "outlineNegative" }),
+      style: bentoSprinkles({ borderColor: "outlineNegative" }),
     },
     {
       variants: {
         kind: "secondary",
         hasOutline: true,
       },
-      style: bentoSprinkles({ outlineColor: "outlineDecorative" }),
+      style: bentoSprinkles({ borderColor: "outlineDecorative" }),
     },
   ],
 });

--- a/packages/bento-design-system/src/util/atoms.ts
+++ b/packages/bento-design-system/src/util/atoms.ts
@@ -126,4 +126,12 @@ export const statusProperties = {
   textDecoration: ["none", "underline"],
   fill: { ...color, ...background, inherit: "inherit" },
   borderColor: { ...color, transparent: "transparent" },
+  borderStyle: {
+    solid: "solid",
+    dashed: "dashed",
+  },
+  borderWidth: {
+    1: "1px",
+    2: "2px",
+  },
 } as const;


### PR DESCRIPTION
This fixes the behavior on Safari.

I was tempted to also remove `outline...` from the atoms, but it would be a breaking change, so I'll save that for a future PR.

Before:
<img width="268" alt="image" src="https://user-images.githubusercontent.com/691940/171133616-251aeee4-1ee5-4062-89b4-e65442b15a59.png">

After:
<img width="270" alt="image" src="https://user-images.githubusercontent.com/691940/171133728-04ce7d87-8fdf-4162-aa0e-35b0a0eacdb1.png">

