### PR TITLE
Add explicit grid-auto-rows: max-content to Table rows

### DIFF
--- a/packages/bento-design-system/src/Table/Table.css.ts
+++ b/packages/bento-design-system/src/Table/Table.css.ts
@@ -2,6 +2,10 @@ import { style } from "@vanilla-extract/css";
 import { bentoSprinkles } from "../internal";
 import { strictRecipe } from "../util/strictRecipe";
 
+export const table = style({
+  gridAutoRows: "max-content",
+});
+
 export const lastLeftStickyColumn = bentoSprinkles({
   background: "backgroundPrimary",
   paddingRight: 8,

--- a/packages/bento-design-system/src/Table/createTable.tsx
+++ b/packages/bento-design-system/src/Table/createTable.tsx
@@ -31,6 +31,7 @@ import {
   lastLeftStickyColumn,
   sectionHeader,
   sectionHeaderContainer,
+  table,
 } from "./Table.css";
 import { Column as ColumnType, Row as RowType } from "./types";
 import {
@@ -279,6 +280,7 @@ export function createTable(
         {...getTableProps()}
         alignItems="stretch"
         overflow="auto"
+        className={table}
         style={{ ...getTableProps().style, gridTemplateColumns }}
       >
         {headerGroups.map((headerGroup) =>


### PR DESCRIPTION
This fixes a bug in Safari which seems to manifest in these
circumstances:
- the Table is included in a container that grows vertically (e.g. a
  Stack)
- the Table scrolls horizontally (i.e. some columns overflow)

In this scenario, all rows become taller (over ~150px).
This may be due to how Safari interprets height: 100% (since wrapping
the Table in a simple `Box` seems to fix it) but it's only an educated
guess at this point.