### PR TITLE
Fix borderStyle atoms

### DIFF
--- a/packages/bento-design-system/src/util/atoms.ts
+++ b/packages/bento-design-system/src/util/atoms.ts
@@ -27,13 +27,6 @@ export const unconditionalProperties = {
   overflow: ["hidden", "visible", "auto"],
   overflowX: ["hidden", "visible", "auto"],
   overflowY: ["hidden", "visible", "auto"],
-  borderBottomWidth: {
-    1: "1px",
-    2: "2px",
-  },
-  borderStyle: {
-    solid: "solid",
-  },
   isolation: ["auto", "isolate"],
 } as const;
 
@@ -132,6 +125,10 @@ export const statusProperties = {
     dashed: "dashed",
   },
   borderWidth: {
+    1: "1px",
+    2: "2px",
+  },
+  borderBottomWidth: {
     1: "1px",
     2: "2px",
   },


### PR DESCRIPTION
Remove the duplicate `borderStyle` atoms from `unconditionalProperties`.

I’ve also moved the `borderBottomStyle` to `statusProperties` for consistency