### PR TITLE
#293: Add iconSize to Disclosure config

### DIFF
--- a/packages/bento-design-system/src/Disclosure/Config.ts
+++ b/packages/bento-design-system/src/Disclosure/Config.ts
@@ -15,4 +15,8 @@ export type DisclosureConfig = {
     open: (props: IconProps) => Children;
     closed: (props: IconProps) => Children;
   };
+  iconSize: {
+    1: IconProps["size"];
+    2: IconProps["size"];
+  };
 };

--- a/packages/bento-design-system/src/Disclosure/createDisclosure.tsx
+++ b/packages/bento-design-system/src/Disclosure/createDisclosure.tsx
@@ -68,7 +68,7 @@ export function createDisclosure(config: DisclosureConfig) {
             reverse={iconPosition === "trailing"}
           >
             <Column width="content">
-              {icon({ size: 16, color: level === 1 ? "primary" : "secondary" })}
+              {icon({ size: config.iconSize[level], color: level === 1 ? "primary" : "secondary" })}
             </Column>
             <Title size={config.titleSize[level]} color={level === 1 ? "default" : "secondary"}>
               {title}

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -168,6 +168,10 @@ export const disclosure: DisclosureConfig = {
     open: IconChevronUp,
     closed: IconChevronDown,
   },
+  iconSize: {
+    1: 16,
+    2: 16,
+  },
 };
 
 export const disclosureGroup: DisclosureGroupConfig = {


### PR DESCRIPTION
Closes #293

## Test Plan

### tests performed

By changing the default config in the storybook you can verify that the icon's size changes as expected

   <img width="299" alt="Schermata 2022-07-22 alle 16 42 37" src="https://user-images.githubusercontent.com/34537387/180463797-650fc145-26e3-4a0d-85b0-577e2b6436f0.png">
   <img width="301" alt="Schermata 2022-07-22 alle 16 42 44" src="https://user-images.githubusercontent.com/34537387/180463795-a6922959-7e66-48a2-8f3f-eeeb1fae0b9d.png">



The default configuration for `iconSize` is equal to the previous behavior 