### PR TITLE
#262: Bug: Tables lose their sorting status when interacting with them

### DIFF
--- a/packages/bento-design-system/src/Table/createTable.tsx
+++ b/packages/bento-design-system/src/Table/createTable.tsx
@@ -177,6 +177,7 @@ export function createTable(
         },
         orderByFn: customOrderByFn,
         manualSortBy: Boolean(onSort),
+        autoResetSortBy: false,
       },
       useGridLayout,
       useGroupBy,


### PR DESCRIPTION
Closes #262

## Test Plan

### tests performed

The columns' status is not reset when the data change
![Kapture 2022-07-25 at 18 04 16](https://user-images.githubusercontent.com/34537387/180824028-29d1dae0-6b17-4252-91a0-fbecaf92c86c.gif)

