### PR TITLE
Add optional `tooltipContent` to `textWithIcon` and `numberWithIcon` columns

### DIFF
--- a/packages/bento-design-system/src/Table/cells.tsx
+++ b/packages/bento-design-system/src/Table/cells.tsx
@@ -1,7 +1,17 @@
 import { ComponentProps, FunctionComponent } from "react";
 import { CellProps } from "react-table";
 import { ButtonLinkProps } from "../Button/ButtonLink";
-import { LocalizedString, Body, ButtonProps, ChipProps, IconProps, Label, Link } from "..";
+import {
+  LocalizedString,
+  Body,
+  ButtonProps,
+  ChipProps,
+  IconProps,
+  Label,
+  Link,
+  TooltipProps,
+  Children,
+} from "..";
 import { Inline, Inset, Box } from "../internal";
 import { IconButtonProps } from "../IconButton/createIconButton";
 
@@ -39,25 +49,41 @@ export function TextCell({ value, column: { align } }: CellProps<{}, LocalizedSt
   );
 }
 
-export function TextWithIconCell({
-  value: { icon, iconPosition, text },
-  column: { align },
-}: CellProps<
-  {},
-  {
-    icon: FunctionComponent<IconProps> | null;
-    iconPosition: "left" | "right";
-    text: LocalizedString;
-  }
->) {
-  return (
-    <Inset space={16}>
-      <Inline space={8} alignY="center" align={align} reverse={iconPosition === "right"}>
-        {icon && icon({ size: 12 })}
-        <Body size="medium">{text}</Body>
-      </Inline>
-    </Inset>
-  );
+export function createTextWithIconCell(Tooltip: FunctionComponent<TooltipProps>) {
+  return function TextWithIconCell({
+    value: { icon, iconPosition, text, tooltipContent },
+    column: { align },
+  }: CellProps<
+    {},
+    {
+      icon: FunctionComponent<IconProps> | null;
+      iconPosition: "left" | "right";
+      text: LocalizedString;
+      tooltipContent?: Children;
+    }
+  >) {
+    const icon_ = icon && icon({ size: 12 });
+
+    return (
+      <Inset space={16}>
+        <Inline space={8} alignY="center" align={align} reverse={iconPosition === "right"}>
+          {tooltipContent ? (
+            <Tooltip
+              content={tooltipContent}
+              trigger={(ref, triggerProps) => (
+                <Box ref={ref} {...triggerProps}>
+                  {icon_}
+                </Box>
+              )}
+            />
+          ) : (
+            icon_
+          )}
+          <Body size="medium">{text}</Body>
+        </Inline>
+      </Inset>
+    );
+  };
 }
 
 export function createChipCell<CustomColor extends string>(

--- a/packages/bento-design-system/src/Table/createTable.tsx
+++ b/packages/bento-design-system/src/Table/createTable.tsx
@@ -53,9 +53,9 @@ import {
   iconColumn,
   labelColumn,
   numberColumn,
-  numberWithIconColumn,
   textColumn,
-  textWithIconColumn,
+  createTextWithIconColumn,
+  createNumberWithIconColumn,
 } from "./tableColumn";
 import { ButtonLinkProps } from "../Button/ButtonLink";
 import { IconButtonProps } from "../IconButton/createIconButton";
@@ -498,16 +498,20 @@ export function createTableColumns<CustomChipColor extends string>({
   ButtonLink,
   IconButton,
   Chip,
+  Tooltip,
 }: {
   Button: FunctionComponent<ButtonProps>;
   ButtonLink: FunctionComponent<ButtonLinkProps>;
   Chip: FunctionComponent<ChipProps<CustomChipColor>>;
   IconButton: FunctionComponent<IconButtonProps>;
+  Tooltip: FunctionComponent<TooltipProps>;
 }) {
   const buttonColumn = createButtonColumn(Button);
   const buttonLinkColumn = createButtonLinkColumn(ButtonLink);
   const chipColumn = createChipColumn(Chip);
   const iconButtonColumn = createIconButtonColumn(IconButton);
+  const textWithIconColumn = createTextWithIconColumn(Tooltip);
+  const numberWithIconColumn = createNumberWithIconColumn(Tooltip);
   return {
     custom: column,
     text: textColumn,

--- a/packages/bento-design-system/src/Table/tableColumn.tsx
+++ b/packages/bento-design-system/src/Table/tableColumn.tsx
@@ -1,6 +1,14 @@
 import { CellProps, Column as Column_, Row as Row_ } from "react-table";
 import { useDefaultMessages } from "../util/useDefaultMessages";
-import { LocalizedString, Children, Body, ButtonProps, ChipProps, IconProps } from "..";
+import {
+  LocalizedString,
+  Children,
+  Body,
+  ButtonProps,
+  ChipProps,
+  IconProps,
+  TooltipProps,
+} from "..";
 import { Box } from "../internal";
 import { Column } from "./types";
 import { FunctionComponent } from "react";
@@ -10,11 +18,11 @@ import {
   createButtonLinkCell,
   createChipCell,
   createIconButtonCell,
+  createTextWithIconCell,
   LinkCell,
   IconCell,
   LabelCell,
   TextCell,
-  TextWithIconCell,
 } from "./cells";
 import { IconButtonProps } from "../IconButton/createIconButton";
 
@@ -110,34 +118,38 @@ export function textColumn<A extends string>(options: ColumnOptionsBase<A>) {
   });
 }
 
-export function textWithIconColumn<A extends string>({
-  iconPosition,
-  ...options
-}: ColumnOptionsBase<A> & {
-  iconPosition: "left" | "right";
-}) {
-  return column({
-    ...options,
-    Cell: ({
-      value: _value,
-      ...props
-    }: CellProps<
-      {},
-      {
-        icon: FunctionComponent<IconProps> | null;
-        text: LocalizedString;
-      }
-    >) => {
-      const value = { ..._value, iconPosition };
-      const textWithIconCellProps = {
-        ...props,
-        value,
-        cell: { ...props.cell, value },
-      };
-      return <TextWithIconCell {...textWithIconCellProps} />;
-    },
-    sortType: (a, b) => (a?.text ?? "").localeCompare(b?.text ?? ""),
-  });
+export function createTextWithIconColumn(Tooltip: FunctionComponent<TooltipProps>) {
+  const TextWithIconCell = createTextWithIconCell(Tooltip);
+  return function textWithIconColumn<A extends string>({
+    iconPosition,
+    ...options
+  }: ColumnOptionsBase<A> & {
+    iconPosition: "left" | "right";
+  }) {
+    return column({
+      ...options,
+      Cell: ({
+        value: _value,
+        ...props
+      }: CellProps<
+        {},
+        {
+          icon: FunctionComponent<IconProps> | null;
+          text: LocalizedString;
+          tooltipContent?: Children;
+        }
+      >) => {
+        const value = { ..._value, iconPosition };
+        const textWithIconCellProps = {
+          ...props,
+          value,
+          cell: { ...props.cell, value },
+        };
+        return <TextWithIconCell {...textWithIconCellProps} />;
+      },
+      sortType: (a, b) => (a?.text ?? "").localeCompare(b?.text ?? ""),
+    });
+  };
 }
 
 export function numberColumn<A extends string>({
@@ -161,34 +173,43 @@ export function numberColumn<A extends string>({
   });
 }
 
-export function numberWithIconColumn<A extends string>({
-  valueFormatter,
-  ...options
-}: ColumnOptionsBase<A> & {
-  valueFormatter: (n: number) => LocalizedString;
-}) {
-  return column({
-    ...options,
-    Cell: ({
-      value: { numericValue, icon },
-      ...props
-    }: CellProps<
-      {},
-      {
-        icon: FunctionComponent<IconProps> | null;
-        numericValue: number;
-      }
-    >) => {
-      const value = { text: valueFormatter(numericValue), icon, iconPosition: "right" as const };
-      const textCellProps = {
-        ...props,
-        value,
-        cell: { ...props.cell, value },
-      };
-      return <TextWithIconCell {...textCellProps} />;
-    },
-    sortType: (a, b) => (a?.numericValue || 0) - (b?.numericValue || 0),
-  });
+export function createNumberWithIconColumn(Tooltip: FunctionComponent<TooltipProps>) {
+  const TextWithIconCell = createTextWithIconCell(Tooltip);
+  return function numberWithIconColumn<A extends string>({
+    valueFormatter,
+    ...options
+  }: ColumnOptionsBase<A> & {
+    valueFormatter: (n: number) => LocalizedString;
+  }) {
+    return column({
+      ...options,
+      Cell: ({
+        value: { numericValue, icon, tooltipContent },
+        ...props
+      }: CellProps<
+        {},
+        {
+          icon: FunctionComponent<IconProps> | null;
+          numericValue: number;
+          tooltipContent?: Children;
+        }
+      >) => {
+        const value = {
+          text: valueFormatter(numericValue),
+          icon,
+          iconPosition: "right" as const,
+          tooltipContent,
+        };
+        const textCellProps = {
+          ...props,
+          value,
+          cell: { ...props.cell, value },
+        };
+        return <TextWithIconCell {...textCellProps} />;
+      },
+      sortType: (a, b) => (a?.numericValue || 0) - (b?.numericValue || 0),
+    });
+  };
 }
 
 export function labelColumn<A extends string>(options: ColumnOptionsBase<A>) {

--- a/packages/bento-design-system/src/createBentoComponents.ts
+++ b/packages/bento-design-system/src/createBentoComponents.ts
@@ -215,7 +215,7 @@ function internalCreateBentoComponents<
     Feedback,
     IconButton,
   });
-  const tableColumn = createTableColumns({ Button, ButtonLink, IconButton, Chip });
+  const tableColumn = createTableColumns({ Button, ButtonLink, IconButton, Chip, Tooltip });
 
   const Tabs = createTabs(merge(defaultConfigs.folderTabs, config.tabs ?? {}));
 

--- a/packages/storybook/stories/Components/Table.stories.tsx
+++ b/packages/storybook/stories/Components/Table.stories.tsx
@@ -96,6 +96,7 @@ const exampleData = [
     country: {
       icon: IconInformative,
       text: formatMessage("US"),
+      tooltipContent: formatMessage("United States"),
     },
     button: {
       label: formatMessage("Row 1"),
@@ -120,6 +121,7 @@ const exampleData = [
     country: {
       icon: IconInformative,
       text: formatMessage("US"),
+      tooltipContent: formatMessage("United States"),
     },
     button: {
       label: formatMessage("Row 2"),
@@ -144,6 +146,7 @@ const exampleData = [
     country: {
       icon: IconInformative,
       text: formatMessage("US"),
+      tooltipContent: formatMessage("United States"),
     },
     button: {
       label: formatMessage("Row 3"),
@@ -189,6 +192,7 @@ const exampleData = [
     country: {
       icon: IconInformative,
       text: formatMessage("US"),
+      tooltipContent: formatMessage("United States"),
     },
     button: {
       label: formatMessage("Row 5"),


### PR DESCRIPTION
Allow to optionally pass `tooltipContent` to columns with an icon

<img width="599" alt="image" src="https://user-images.githubusercontent.com/691940/181292736-6522c7c0-eb47-40f5-b334-66b2671c4022.png">


Originally reported in #312 