### PR TITLE
Add sideEffects field to package.json to allow bundlers to treeshake

### DIFF
--- a/packages/bento-design-system/package.json
+++ b/packages/bento-design-system/package.json
@@ -6,6 +6,7 @@
   "files": [
     "lib"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "tsup --minify --clean",
     "prepublishOnly": "pnpm build",

--- a/packages/bento-design-system/package.json
+++ b/packages/bento-design-system/package.json
@@ -6,7 +6,10 @@
   "files": [
     "lib"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css",
+    "*.css.ts"
+  ],
   "scripts": {
     "build": "tsup --minify --clean",
     "prepublishOnly": "pnpm build",


### PR DESCRIPTION
The only side effects we have (according to https://webpack.js.org/guides/tree-shaking/) are the .css and .css.ts imports, which need to be included in the final bundle regardles.

Specifying them in the `sideEffects` field should improve three-shakeability