### PR TITLE
#292: Autofocus on fields

### DIFF
--- a/packages/bento-design-system/src/Checkbox/createInternalCheckbox.tsx
+++ b/packages/bento-design-system/src/Checkbox/createInternalCheckbox.tsx
@@ -54,7 +54,7 @@ type Props = {
 export function createInternalCheckbox(config: SelectionControlConfig) {
   return function InternalCheckbox({ option, inputRef, inputProps }: Props) {
     const { fieldProps, labelProps } = useLabel(option);
-    const { isFocusVisible, focusProps } = useFocusRing();
+    const { isFocusVisible, focusProps } = useFocusRing({ autoFocus: inputProps.autoFocus });
     return (
       <Box
         as="label"

--- a/packages/bento-design-system/src/CheckboxGroupField/createCheckboxGroupField.tsx
+++ b/packages/bento-design-system/src/CheckboxGroupField/createCheckboxGroupField.tsx
@@ -8,6 +8,7 @@ import { CheckboxGroupState, useCheckboxGroupState } from "@react-stately/checkb
 import { Box, Inline, Inset, Stack } from "../internal";
 import { SelectionControlConfig, SelectionControlGroupConfig } from "../Field/Config";
 import { Children } from "../util/Children";
+import { FocusScope } from "@react-aria/focus";
 
 export type CheckboxOption = {
   value: string;
@@ -64,23 +65,25 @@ export function createCheckboxGroupField(
     ));
 
     return (
-      <Box {...groupProps} aria-describedby={fieldProps["aria-describedby"]} color={undefined}>
-        <Field
-          {...props}
-          label={props.label}
-          labelProps={labelProps}
-          assistiveTextProps={descriptionProps}
-          errorMessageProps={errorMessageProps}
-        >
-          <Inset spaceY={config.group.paddingY}>
-            {(props.orientation || "vertical") === "vertical" ? (
-              <Stack space={config.group.internalSpacing.vertical}>{groupOptions}</Stack>
-            ) : (
-              <Inline space={config.group.internalSpacing.horizontal}>{groupOptions}</Inline>
-            )}
-          </Inset>
-        </Field>
-      </Box>
+      <FocusScope autoFocus={props.autoFocus}>
+        <Box {...groupProps} aria-describedby={fieldProps["aria-describedby"]} color={undefined}>
+          <Field
+            {...props}
+            label={props.label}
+            labelProps={labelProps}
+            assistiveTextProps={descriptionProps}
+            errorMessageProps={errorMessageProps}
+          >
+            <Inset spaceY={config.group.paddingY}>
+              {(props.orientation || "vertical") === "vertical" ? (
+                <Stack space={config.group.internalSpacing.vertical}>{groupOptions}</Stack>
+              ) : (
+                <Inline space={config.group.internalSpacing.horizontal}>{groupOptions}</Inline>
+              )}
+            </Inset>
+          </Field>
+        </Box>
+      </FocusScope>
     );
   };
 }

--- a/packages/bento-design-system/src/CheckboxGroupField/createCheckboxGroupField.tsx
+++ b/packages/bento-design-system/src/CheckboxGroupField/createCheckboxGroupField.tsx
@@ -13,6 +13,7 @@ export type CheckboxOption = {
   value: string;
   label: Children;
   isDisabled?: boolean;
+  autoFocus?: boolean;
 };
 
 type Props = FieldProps<string[]> & {

--- a/packages/bento-design-system/src/DateField/createDateField.tsx
+++ b/packages/bento-design-system/src/DateField/createDateField.tsx
@@ -56,9 +56,11 @@ export function createDateField(
   return function DateField(props: Props) {
     const startInputRef = useRef<HTMLInputElement>(null);
     const endInputRef = useRef<HTMLInputElement>(null);
-    const [focusedInput, setFocusedInput] = useState<FocusedInput>(null);
-    const [isFocused, setIsFocused] = useState(false);
-    const [isOpen, setIsOpen] = useState(false);
+    const [focusedInput, setFocusedInput] = useState<FocusedInput>(
+      props.autoFocus ? "startDate" : null
+    );
+    const [isFocused, setIsFocused] = useState(props.autoFocus ?? false);
+    const [isOpen, setIsOpen] = useState(props.autoFocus ?? false);
     const validationState = props.readOnly ? "notSet" : props.issues ? "invalid" : "valid";
 
     const {

--- a/packages/bento-design-system/src/Field/FieldProps.ts
+++ b/packages/bento-design-system/src/Field/FieldProps.ts
@@ -12,4 +12,5 @@ export type FieldProps<V, VO = V> = {
   issues?: NonEmptyArray<Children>;
   disabled?: boolean;
   assistiveText?: Children;
+  autoFocus?: boolean;
 };

--- a/packages/bento-design-system/src/Form/Form.tsx
+++ b/packages/bento-design-system/src/Form/Form.tsx
@@ -44,7 +44,7 @@ export function createForm(
     autoFocus,
   }: Props) {
     return (
-      <FocusScope contain restoreFocus autoFocus={autoFocus}>
+      <FocusScope autoFocus={autoFocus}>
         <Box as="form" onSubmit={(e) => e.preventDefault()}>
           <ContentBlock maxWidth={700}>
             <Stack space={config.formSpacing}>

--- a/packages/bento-design-system/src/Form/Form.tsx
+++ b/packages/bento-design-system/src/Form/Form.tsx
@@ -12,6 +12,7 @@ import {
 import { Box, Stack } from "../internal";
 import { Headline } from "../Typography/Headline/Headline";
 import { FormConfig } from "./Config";
+import { FocusScope } from "@react-aria/focus";
 
 type Props = {
   children: Children;
@@ -21,6 +22,7 @@ type Props = {
   secondaryButton?: Omit<ButtonProps, "kind" | "hierarchy">;
   error?: LocalizedString;
   actionsSize?: ButtonProps["size"];
+  autoFocus?: boolean;
 };
 
 export function createForm(
@@ -39,34 +41,37 @@ export function createForm(
     secondaryButton,
     error,
     actionsSize = config.defaultActionsSize,
+    autoFocus,
   }: Props) {
     return (
-      <Box as="form" onSubmit={(e) => e.preventDefault()}>
-        <ContentBlock maxWidth={700}>
-          <Stack space={config.formSpacing}>
-            {(title || description) && (
-              <Stack space={config.headerSpacing}>
-                {title &&
-                  (config.headerTitle.kind === "display" ? (
-                    <Display size={config.headerTitle.size}>{title}</Display>
-                  ) : (
-                    <Headline size={config.headerTitle.size}>{title}</Headline>
-                  ))}
-                {description && <Body size={config.headerDescriptionSize}>{description}</Body>}
-              </Stack>
-            )}
-            {children}
-            {(submitButton || secondaryButton) && (
-              <Actions
-                size={actionsSize}
-                primaryAction={submitButton}
-                secondaryAction={secondaryButton}
-                error={error}
-              />
-            )}
-          </Stack>
-        </ContentBlock>
-      </Box>
+      <FocusScope contain restoreFocus autoFocus={autoFocus}>
+        <Box as="form" onSubmit={(e) => e.preventDefault()}>
+          <ContentBlock maxWidth={700}>
+            <Stack space={config.formSpacing}>
+              {(title || description) && (
+                <Stack space={config.headerSpacing}>
+                  {title &&
+                    (config.headerTitle.kind === "display" ? (
+                      <Display size={config.headerTitle.size}>{title}</Display>
+                    ) : (
+                      <Headline size={config.headerTitle.size}>{title}</Headline>
+                    ))}
+                  {description && <Body size={config.headerDescriptionSize}>{description}</Body>}
+                </Stack>
+              )}
+              {children}
+              {(submitButton || secondaryButton) && (
+                <Actions
+                  size={actionsSize}
+                  primaryAction={submitButton}
+                  secondaryAction={secondaryButton}
+                  error={error}
+                />
+              )}
+            </Stack>
+          </ContentBlock>
+        </Box>
+      </FocusScope>
     );
   };
 }

--- a/packages/bento-design-system/src/NumberField/createNumberField.tsx
+++ b/packages/bento-design-system/src/NumberField/createNumberField.tsx
@@ -11,7 +11,6 @@ import { NumberInputProps } from "../NumberInput/createNumberInput";
 
 type Props = FieldProps<number | undefined, number> & {
   placeholder: LocalizedString;
-  autoFocus?: boolean;
   isReadOnly?: boolean;
 } & FormatProps &
   Pick<NumberFieldStateProps, "minValue" | "maxValue" | "step">;

--- a/packages/bento-design-system/src/RadioGroupField/createRadioGroupField.tsx
+++ b/packages/bento-design-system/src/RadioGroupField/createRadioGroupField.tsx
@@ -9,7 +9,7 @@ import { useField } from "@react-aria/label";
 import { radioOption } from "./RadioGroupField.css";
 import { useRef } from "react";
 import { VisuallyHidden } from "@react-aria/visually-hidden";
-import { useFocusRing } from "@react-aria/focus";
+import { FocusScope, useFocusRing } from "@react-aria/focus";
 import { Radio } from "./Radio";
 import { SelectionControlConfig, SelectionControlGroupConfig } from "../Field/Config";
 
@@ -59,24 +59,26 @@ export function createRadioGroupField(
     ));
 
     return (
-      <Box {...radioGroupProps} color={undefined}>
-        <Field
-          {...props}
-          label={props.label}
-          labelProps={labelProps}
-          assistiveTextProps={descriptionProps}
-          errorMessageProps={errorMessageProps}
-          labelElement="span"
-        >
-          <Inset spaceY={config.group.paddingY}>
-            {(props.orientation || "vertical") === "vertical" ? (
-              <Stack space={config.group.internalSpacing.vertical}>{radioOptions}</Stack>
-            ) : (
-              <Inline space={config.group.internalSpacing.horizontal}>{radioOptions}</Inline>
-            )}
-          </Inset>
-        </Field>
-      </Box>
+      <FocusScope autoFocus={props.autoFocus}>
+        <Box {...radioGroupProps} color={undefined}>
+          <Field
+            {...props}
+            label={props.label}
+            labelProps={labelProps}
+            assistiveTextProps={descriptionProps}
+            errorMessageProps={errorMessageProps}
+            labelElement="span"
+          >
+            <Inset spaceY={config.group.paddingY}>
+              {(props.orientation || "vertical") === "vertical" ? (
+                <Stack space={config.group.internalSpacing.vertical}>{radioOptions}</Stack>
+              ) : (
+                <Inline space={config.group.internalSpacing.horizontal}>{radioOptions}</Inline>
+              )}
+            </Inset>
+          </Field>
+        </Box>
+      </FocusScope>
     );
   };
 

--- a/packages/bento-design-system/src/SearchBar/createSearchBar.tsx
+++ b/packages/bento-design-system/src/SearchBar/createSearchBar.tsx
@@ -19,6 +19,7 @@ type Props = O.AtLeast<Pick<HTMLAttributes<HTMLInputElement>, "aria-label" | "ar
   placeholder: LocalizedString;
   disabled?: boolean;
   clearButtonLabel?: LocalizedString;
+  autoFocus?: boolean;
 };
 
 export function createSearchBar(

--- a/packages/bento-design-system/src/SelectField/createSelectField.tsx
+++ b/packages/bento-design-system/src/SelectField/createSelectField.tsx
@@ -31,7 +31,6 @@ type Props<A, IsMulti extends boolean> = (IsMulti extends false
   options: Array<SelectOption<A>>;
   isMulti?: IsMulti;
   noOptionsMessage?: LocalizedString;
-  autoFocus?: boolean;
   isReadOnly?: boolean;
   searchable?: boolean;
 } & (IsMulti extends true

--- a/packages/bento-design-system/src/Slider/createSlider.tsx
+++ b/packages/bento-design-system/src/Slider/createSlider.tsx
@@ -19,6 +19,7 @@ type Props = {
   outputProps: OutputHTMLAttributes<HTMLOutputElement>;
   numberFormatter: Intl.NumberFormat;
   hideThumbValue?: boolean;
+  autoFocus?: boolean;
 };
 
 export function createSlider(config: SliderConfig) {
@@ -70,6 +71,7 @@ export function createSlider(config: SliderConfig) {
               outputProps={props.outputProps}
               disabled={props.disabled}
               showValue={!props.hideThumbValue}
+              autoFocus={props.autoFocus}
             />
             {props.type === "double" && (
               <Thumb
@@ -101,6 +103,7 @@ export function createSlider(config: SliderConfig) {
     outputProps: OutputHTMLAttributes<HTMLOutputElement>;
     disabled?: boolean;
     showValue: boolean;
+    autoFocus?: boolean;
   };
 
   function Thumb(props: ThumbProps) {
@@ -110,7 +113,7 @@ export function createSlider(config: SliderConfig) {
       { index, trackRef, inputRef, isDisabled: props.disabled },
       state
     );
-    const { focusProps, isFocusVisible } = useFocusRing();
+    const { focusProps, isFocusVisible } = useFocusRing({ autoFocus: props.autoFocus });
 
     const output = (
       <Box as="output" {...props.outputProps} color={undefined}>
@@ -139,6 +142,7 @@ export function createSlider(config: SliderConfig) {
             borderRadius={config.thumbRadius}
             width={config.thumbWidth}
             height={config.thumbHeight}
+            autoFocus={props.autoFocus}
           >
             <VisuallyHidden>
               <input ref={inputRef} {...mergeProps(inputProps, focusProps)} />

--- a/packages/bento-design-system/src/Slider/createSlider.tsx
+++ b/packages/bento-design-system/src/Slider/createSlider.tsx
@@ -1,4 +1,4 @@
-import { useFocusRing } from "@react-aria/focus";
+import { FocusScope, useFocusRing } from "@react-aria/focus";
 import { useSliderThumb } from "@react-aria/slider";
 import { mergeProps } from "@react-aria/utils";
 import { VisuallyHidden } from "@react-aria/visually-hidden";
@@ -25,74 +25,78 @@ type Props = {
 export function createSlider(config: SliderConfig) {
   return function Slider(props: Props) {
     return (
-      <Box className={slider} {...props.groupProps} color={undefined}>
-        <Columns space={24} alignY="center">
-          <Column width="content">
-            <Label size="large" color={props.disabled ? "disabled" : "secondary"}>
-              {props.numberFormatter.format(props.state.getThumbMinValue(0))}
-            </Label>
-          </Column>
-          <Box
-            className={trackContainer}
-            height={config.thumbHeight}
-            {...props.trackProps}
-            ref={props.trackRef}
-            color={undefined}
-          >
+      <FocusScope autoFocus={props.autoFocus}>
+        <Box className={slider} {...props.groupProps} color={undefined}>
+          <Columns space={24} alignY="center">
+            <Column width="content">
+              <Label size="large" color={props.disabled ? "disabled" : "secondary"}>
+                {props.numberFormatter.format(props.state.getThumbMinValue(0))}
+              </Label>
+            </Column>
             <Box
-              className={trackInactive}
-              disabled={props.disabled}
-              borderRadius={config.trailRadius}
-              style={{
-                height: config.trailHeight,
-                top: (config.thumbHeight - config.trailHeight) / 2,
-              }}
-            />
-            <Box
-              className={trackActive}
-              color={config.trailColor}
-              background="currentColor"
-              disabled={props.disabled}
-              borderRadius={config.trailRadius}
-              style={{
-                height: config.trailHeight,
-                top: (config.thumbHeight - config.trailHeight) / 2,
-                left: props.type === "single" ? 0 : `${props.state.getThumbPercent(0) * 100}%`,
-                width:
-                  props.type === "single"
-                    ? `${props.state.getThumbPercent(0) * 100}%`
-                    : `${(props.state.getThumbPercent(1) - props.state.getThumbPercent(0)) * 100}%`,
-              }}
-            />
-            <Thumb
-              index={0}
-              state={props.state}
-              trackRef={props.trackRef}
-              outputProps={props.outputProps}
-              disabled={props.disabled}
-              showValue={!props.hideThumbValue}
-              autoFocus={props.autoFocus}
-            />
-            {props.type === "double" && (
+              className={trackContainer}
+              height={config.thumbHeight}
+              {...props.trackProps}
+              ref={props.trackRef}
+              color={undefined}
+            >
+              <Box
+                className={trackInactive}
+                disabled={props.disabled}
+                borderRadius={config.trailRadius}
+                style={{
+                  height: config.trailHeight,
+                  top: (config.thumbHeight - config.trailHeight) / 2,
+                }}
+              />
+              <Box
+                className={trackActive}
+                color={config.trailColor}
+                background="currentColor"
+                disabled={props.disabled}
+                borderRadius={config.trailRadius}
+                style={{
+                  height: config.trailHeight,
+                  top: (config.thumbHeight - config.trailHeight) / 2,
+                  left: props.type === "single" ? 0 : `${props.state.getThumbPercent(0) * 100}%`,
+                  width:
+                    props.type === "single"
+                      ? `${props.state.getThumbPercent(0) * 100}%`
+                      : `${
+                          (props.state.getThumbPercent(1) - props.state.getThumbPercent(0)) * 100
+                        }%`,
+                }}
+              />
               <Thumb
-                index={1}
+                index={0}
                 state={props.state}
                 trackRef={props.trackRef}
                 outputProps={props.outputProps}
                 disabled={props.disabled}
                 showValue={!props.hideThumbValue}
+                autoFocus={props.autoFocus}
               />
-            )}
-          </Box>
-          <Column width="content">
-            <Label size="large" color={props.disabled ? "disabled" : "secondary"}>
-              {props.numberFormatter.format(
-                props.state.getThumbMaxValue(props.type === "single" ? 0 : 1)
+              {props.type === "double" && (
+                <Thumb
+                  index={1}
+                  state={props.state}
+                  trackRef={props.trackRef}
+                  outputProps={props.outputProps}
+                  disabled={props.disabled}
+                  showValue={!props.hideThumbValue}
+                />
               )}
-            </Label>
-          </Column>
-        </Columns>
-      </Box>
+            </Box>
+            <Column width="content">
+              <Label size="large" color={props.disabled ? "disabled" : "secondary"}>
+                {props.numberFormatter.format(
+                  props.state.getThumbMaxValue(props.type === "single" ? 0 : 1)
+                )}
+              </Label>
+            </Column>
+          </Columns>
+        </Box>
+      </FocusScope>
     );
   };
 

--- a/packages/bento-design-system/src/SliderField/createSliderField.tsx
+++ b/packages/bento-design-system/src/SliderField/createSliderField.tsx
@@ -19,7 +19,6 @@ type Props = (
   maxValue: number;
   step?: number;
   dragStep?: number;
-  autoFocus?: boolean;
   hideThumbValue?: boolean;
 } & FormatProps;
 


### PR DESCRIPTION
Closes #292

## Test Plan

### tests performed

- By using the arg `autoFocus: true` in the stories, the components `TextField`, `TextArea`, `SelectField`, `RadioGroupField`, `SearchBar`, `CheckboxGroupField`, `Slider`, `Form` and `DateField` actually get the focus. 
