### PR TITLE
#319: Use `{ custom: number }` convention for Illustration size

### DIFF
--- a/packages/bento-design-system/src/Illustrations/IllustrationProps.ts
+++ b/packages/bento-design-system/src/Illustrations/IllustrationProps.ts
@@ -1,5 +1,5 @@
 export type IllustrationProps = {
-  size: 24 | 32 | 40 | 80 | 160 | number;
+  size: 24 | 32 | 40 | 80 | 160 | { custom: number };
 } & (
   | {
       style: "color";

--- a/packages/bento-design-system/src/Illustrations/svgIllustrationProps.ts
+++ b/packages/bento-design-system/src/Illustrations/svgIllustrationProps.ts
@@ -22,5 +22,6 @@ function outlineColor(color: (IllustrationProps & { style: "outline" })["color"]
 }
 
 function sizeToDimensions(size: IllustrationProps["size"]): { width: number; height: number } {
-  return { width: size, height: size };
+  const s = typeof size === "object" ? size.custom : size;
+  return { width: s, height: s };
 }


### PR DESCRIPTION
Closes #319
