### PR TITLE
Migrate storybook to new 0.13 API and cleanup formatMessage

### DIFF
--- a/packages/bento-design-system/src/useComponentsShowcase.tsx
+++ b/packages/bento-design-system/src/useComponentsShowcase.tsx
@@ -40,9 +40,6 @@ import { SelectField } from "./SelectField/SelectField";
 import { TextField } from "./TextField/TextField";
 import { Body } from "./Typography/Body/Body";
 import { Title } from "./Typography/Title/Title";
-import { unsafeLocalizedString } from "./util/LocalizedString";
-
-const formatMessage = unsafeLocalizedString;
 
 type ComponentShowcase<
   C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
@@ -118,7 +115,7 @@ function componentShowcase<
 
   return (
     <Stack space={24}>
-      <Title size="large">{formatMessage(title)}</Title>
+      <Title size="large">{title}</Title>
       {iframe ? <IFrame height={400}>{content}</IFrame> : content}
     </Stack>
   );
@@ -126,33 +123,33 @@ function componentShowcase<
 
 export function useComponentsShowcase({ action }: { action: (s: string) => () => void }) {
   const buttonSharedProps = {
-    label: formatMessage("Button"),
+    label: "Button",
     onPress: action("onPress"),
   } as const;
 
   const iconButtonSharedProps = {
-    label: formatMessage("Icon Button"),
+    label: "Icon Button",
     onPress: action("onPress"),
     icon: IconIdea,
     size: 16,
   } as const;
 
   const bannerSharedProps = {
-    title: formatMessage("Title"),
-    description: formatMessage("A description of what's going on"),
+    title: "Title",
+    description: "A description of what's going on",
     action: {
-      label: formatMessage("Action"),
+      label: "Action",
       onPress: action("onPress"),
     },
-    dismissButtonLabel: formatMessage("Dismiss"),
+    dismissButtonLabel: "Dismiss",
     onDismiss: action("onDismiss"),
   } as const;
 
   const feedbackSharedProps = {
-    title: formatMessage("Title"),
+    title: "Title",
     status: "positive",
-    description: formatMessage("Description"),
-    action: { label: formatMessage("Action"), onPress: action("onPress") },
+    description: "Description",
+    action: { label: "Action", onPress: action("onPress") },
   } as const;
 
   const [formState, setFormState] = useState({
@@ -172,7 +169,7 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
         componentShowcase({
           title: "AreaLoader",
           Component: AreaLoader,
-          variants: [[{ message: formatMessage("Loading...") }]],
+          variants: [[{ message: "Loading..." }]],
           absolute: true,
         }),
         componentShowcase({
@@ -186,9 +183,9 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
           variants: [
             [
               {
-                primaryAction: { label: formatMessage("Primary"), onPress: action("onPress") },
+                primaryAction: { label: "Primary", onPress: action("onPress") },
                 secondaryAction: {
-                  label: formatMessage("Secondary"),
+                  label: "Secondary",
                   onPress: action("onPress"),
                 },
               },
@@ -214,11 +211,11 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
             [
               {
                 items: [
-                  { label: formatMessage("Root"), href: "" },
-                  { label: formatMessage("1st level"), href: "" },
-                  { label: formatMessage("2nd level"), href: "" },
-                  { label: formatMessage("3rd level"), href: "" },
-                  { label: formatMessage("Current page") },
+                  { label: "Root", href: "" },
+                  { label: "1st level", href: "" },
+                  { label: "2nd level", href: "" },
+                  { label: "3rd level", href: "" },
+                  { label: "Current page" },
                 ],
               },
             ],
@@ -255,8 +252,8 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                 padding: 24,
                 children: (
                   <Stack space={8}>
-                    <Title size="medium">{formatMessage("Experiment name")}</Title>
-                    <Body size="large">{formatMessage("Experiment description")}</Body>
+                    <Title size="medium">Experiment name</Title>
+                    <Body size="large">Experiment description</Body>
                   </Stack>
                 ),
               },
@@ -268,11 +265,11 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
           Component: Chip,
           variants: [
             [
-              { color: "green", label: formatMessage("Chip") },
-              { color: "green", label: formatMessage("Chip"), icon: IconCheck },
+              { color: "green", label: "Chip" },
+              { color: "green", label: "Chip", icon: IconCheck },
               {
                 color: "green",
-                label: formatMessage("Chip"),
+                label: "Chip",
                 icon: IconCheck,
                 onDismiss: action("onDismiss"),
               },
@@ -287,38 +284,26 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
               {
                 items: [
                   {
-                    title: formatMessage("Section 1"),
+                    title: "Section 1",
                     initialIsOpen: true,
-                    children: (
-                      <Body size="large">{formatMessage("Content of the first section")}</Body>
-                    ),
+                    children: <Body size="large">Content of the first section</Body>,
                   },
                   {
-                    title: formatMessage("Section 2"),
-                    children: (
-                      <Body size="large">{formatMessage("Content of the second section")}</Body>
-                    ),
+                    title: "Section 2",
+                    children: <Body size="large">Content of the second section</Body>,
                   },
                   {
-                    title: formatMessage("Section 3"),
+                    title: "Section 3",
                     initialIsOpen: true,
                     items: [
                       {
-                        title: formatMessage("Subsection 3.1"),
-                        children: (
-                          <Body size="large">
-                            {formatMessage("Content of the first subsection")}
-                          </Body>
-                        ),
+                        title: "Subsection 3.1",
+                        children: <Body size="large">Content of the first subsection</Body>,
                         initialIsOpen: true,
                       },
                       {
-                        title: formatMessage("Subsection 3.2"),
-                        children: (
-                          <Body size="large">
-                            {formatMessage("Content of the second subsection")}
-                          </Body>
-                        ),
+                        title: "Subsection 3.2",
+                        children: <Body size="large">Content of the second subsection</Body>,
                       },
                     ],
                   },
@@ -343,32 +328,29 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
           variants: [
             [
               {
-                title: formatMessage("Form title"),
-                description: formatMessage("Form description"),
-                submitButton: { label: formatMessage("Submit"), onPress: action("Submit") },
-                secondaryButton: { label: formatMessage("Cancel"), onPress: action("Cancel") },
+                title: "Form title",
+                description: "Form description",
+                submitButton: { label: "Submit", onPress: action("Submit") },
+                secondaryButton: { label: "Cancel", onPress: action("Cancel") },
                 children: (
                   <>
-                    <FormSection
-                      title={formatMessage("Section title")}
-                      description={formatMessage("Section description")}
-                    >
+                    <FormSection title="Section title" description="Section description">
                       <FormRow>
                         <TextField
                           name="firstName"
                           onBlur={action("onBlur")}
                           value={formState.firstName}
                           onChange={(firstName) => setFormState((s) => ({ ...s, firstName }))}
-                          label={formatMessage("First Name")}
-                          placeholder={formatMessage("Insert the first name")}
+                          label="First Name"
+                          placeholder="Insert the first name"
                         />
                         <TextField
                           name="lastName"
                           onBlur={action("onBlur")}
                           value={formState.lastName}
                           onChange={(lastName) => setFormState((s) => ({ ...s, lastName }))}
-                          label={formatMessage("Last Name")}
-                          placeholder={formatMessage("Insert the last name")}
+                          label="Last Name"
+                          placeholder="Insert the last name"
                         />
                       </FormRow>
                       <FormRow>
@@ -379,12 +361,12 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                           onChange={(status: string | undefined) =>
                             setFormState((s) => ({ ...s, status }))
                           }
-                          label={formatMessage("Status")}
-                          placeholder={formatMessage("Choose an option")}
+                          label="Status"
+                          placeholder="Choose an option"
                           options={[
-                            { label: formatMessage("Open"), value: "open" },
-                            { label: formatMessage("Closed"), value: "closed" },
-                            { label: formatMessage("Pending"), value: "pending" },
+                            { label: "Open", value: "open" },
+                            { label: "Closed", value: "closed" },
+                            { label: "Pending", value: "pending" },
                           ]}
                         />
                       </FormRow>
@@ -394,11 +376,11 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                           onBlur={action("onBlur")}
                           value={formState.gender}
                           onChange={(gender) => setFormState((s) => ({ ...s, gender }))}
-                          label={formatMessage("Gender")}
+                          label="Gender"
                           options={[
-                            { label: formatMessage("Male"), value: "male" },
-                            { label: formatMessage("Female"), value: "female" },
-                            { label: formatMessage("Other"), value: "other" },
+                            { label: "Male", value: "male" },
+                            { label: "Female", value: "female" },
+                            { label: "Other", value: "other" },
                           ]}
                         />
                       </FormRow>
@@ -410,7 +392,7 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                           onChange={(termsAndConditions: boolean) =>
                             setFormState((s) => ({ ...s, termsAndConditions }))
                           }
-                          label={formatMessage("I have read the terms and conditions")}
+                          label="I have read the terms and conditions"
                         />
                       </FormRow>
                     </FormSection>
@@ -446,20 +428,20 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                 items: [
                   {
                     kind: "single-line",
-                    label: formatMessage("Item 1 - Single line"),
+                    label: "Item 1 - Single line",
                     icon: IconIdea,
                     trailingIcon: IconCheck,
                   },
                   {
                     kind: "two-line",
-                    label: formatMessage("Item 2 - Two lines"),
-                    secondLine: formatMessage("Second line"),
+                    label: "Item 2 - Two lines",
+                    secondLine: "Second line",
                     trailingIcon: IconCheck,
                   },
                   {
                     kind: "overline",
-                    label: formatMessage("Item 3 - Overline"),
-                    overline: formatMessage("Overline"),
+                    label: "Item 3 - Overline",
+                    overline: "Overline",
                     icon: IconIdea,
                   },
                 ],
@@ -476,10 +458,10 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                 kind: "none",
                 size: "medium",
                 destinations: [
-                  { href: "", label: formatMessage("Home"), active: true },
-                  { href: "", label: formatMessage("Experiments") },
-                  { href: "", label: formatMessage("Users") },
-                  { href: "", label: formatMessage("Profile") },
+                  { href: "", label: "Home", active: true },
+                  { href: "", label: "Experiments" },
+                  { href: "", label: "Users" },
+                  { href: "", label: "Profile" },
                 ],
               },
             ],
@@ -488,10 +470,10 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                 kind: "icon",
                 size: "large",
                 destinations: [
-                  { href: "", label: formatMessage("Home"), active: true, icon: IconIdea },
-                  { href: "", label: formatMessage("Experiments"), icon: IconSearch },
-                  { href: "", label: formatMessage("Users"), icon: IconUser },
-                  { href: "", label: formatMessage("Profile"), icon: IconInformative },
+                  { href: "", label: "Home", active: true, icon: IconIdea },
+                  { href: "", label: "Experiments", icon: IconSearch },
+                  { href: "", label: "Users", icon: IconUser },
+                  { href: "", label: "Profile", icon: IconInformative },
                 ],
               },
             ],
@@ -512,7 +494,7 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
           variants: [
             [
               {
-                placeholder: formatMessage("Search anything..."),
+                placeholder: "Search anything...",
                 value: searchBarValue,
                 onChange: searchBarOnChange,
                 "aria-label": "Search",
@@ -528,11 +510,11 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
               {
                 currentStep: 2,
                 steps: [
-                  { label: formatMessage("Step 1") },
-                  { label: formatMessage("Step 2") },
-                  { label: formatMessage("Step 3") },
-                  { label: formatMessage("Step 4") },
-                  { label: formatMessage("Step 5") },
+                  { label: "Step 1" },
+                  { label: "Step 2" },
+                  { label: "Step 3" },
+                  { label: "Step 4" },
+                  { label: "Step 5" },
                 ],
               },
             ],
@@ -547,18 +529,18 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                 {
                   columns: [
                     tableColumn.text({
-                      headerLabel: formatMessage("Name"),
+                      headerLabel: "Name",
                       accessor: "name",
                       sticky: "left",
                     }),
                     tableColumn.number({
-                      headerLabel: formatMessage("Experiments"),
+                      headerLabel: "Experiments",
                       accessor: "experiments",
-                      valueFormatter: (value) => formatMessage(`${value}/100`),
+                      valueFormatter: (value) => `${value}/100`,
                       align: "right",
                     }),
                     tableColumn.chip({
-                      headerLabel: formatMessage("Status"),
+                      headerLabel: "Status",
                       accessor: "status",
                       align: "center",
                     }),
@@ -567,17 +549,17 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                     {
                       name: "John Doe",
                       experiments: 100,
-                      status: { label: formatMessage("done"), color: "green" },
+                      status: { label: "done", color: "green" },
                     },
                     {
                       name: "Jane Doe",
                       experiments: 20,
-                      status: { label: formatMessage("running"), color: "blue" },
+                      status: { label: "running", color: "blue" },
                     },
                     {
                       name: "Jane Doe",
                       experiments: 0,
-                      status: { label: formatMessage("pending"), color: "yellow" },
+                      status: { label: "pending", color: "yellow" },
                     },
                   ],
                 },
@@ -594,10 +576,10 @@ export function useComponentsShowcase({ action }: { action: (s: string) => () =>
                 onChange: tabOnChange as any,
                 size: "medium",
                 tabs: [
-                  { label: formatMessage("Tab 1"), value: "tab1" },
-                  { label: formatMessage("Tab 2"), value: "tab2" },
-                  { label: formatMessage("Tab 3"), value: "tab3" },
-                  { label: formatMessage("Tab 4"), value: "tab4" },
+                  { label: "Tab 1", value: "tab1" },
+                  { label: "Tab 2", value: "tab2" },
+                  { label: "Tab 3", value: "tab3" },
+                  { label: "Tab 4", value: "tab4" },
                 ],
               },
             ],

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -1,11 +1,11 @@
 import { defaultMessages } from "../stories/defaultMessages";
-import { DesignSystemProvider } from "../stories/";
+import { BentoProvider } from "../stories/";
 
 export const decorators = [
   (Story) => (
-    <DesignSystemProvider dismissAfterMs={1000000} defaultMessages={defaultMessages}>
+    <BentoProvider dismissAfterMs={1000000} defaultMessages={defaultMessages}>
       <Story />
-    </DesignSystemProvider>
+    </BentoProvider>
   ),
 ];
 

--- a/packages/storybook/stories/Components/Actions/Actions.stories.tsx
+++ b/packages/storybook/stories/Components/Actions/Actions.stories.tsx
@@ -1,4 +1,4 @@
-import { createComponentStories, formatMessage } from "../../util";
+import { createComponentStories } from "../../util";
 import { Actions } from "../..";
 import { action } from "@storybook/addon-actions";
 
@@ -11,12 +11,12 @@ const { defaultExport, createStory } = createComponentStories({
 });
 
 export const primaryAction = {
-  label: formatMessage("Primary Action"),
+  label: "Primary Action",
   onPress: action("onPress"),
 };
 
 export const asyncPrimaryAction = {
-  label: formatMessage("Primary Action"),
+  label: "Primary Action",
   onPress: () =>
     new Promise((resolve) =>
       setTimeout(() => {
@@ -27,7 +27,7 @@ export const asyncPrimaryAction = {
 };
 
 export const secondaryAction = {
-  label: formatMessage("Secondary Action"),
+  label: "Secondary Action",
   onPress: action("onPress"),
 };
 
@@ -56,14 +56,14 @@ export const TwoActions = createStory({
 export const TwoActionsWithErrorHug = createStory({
   primaryAction,
   secondaryAction,
-  error: formatMessage("Something went wrong"),
+  error: "Something went wrong",
 });
 
 export const TwoActionsWithErrorFit = createStory({
   primaryAction,
   secondaryAction,
   errorBannerWidth: "fill",
-  error: formatMessage("Something went wrong"),
+  error: "Something went wrong",
 });
 
 export const TwoActionsDestructive = createStory({

--- a/packages/storybook/stories/Components/Actions/ActionsLeftAligned.stories.tsx
+++ b/packages/storybook/stories/Components/Actions/ActionsLeftAligned.stories.tsx
@@ -1,5 +1,5 @@
 import { LeftActions } from "../..";
-import { createComponentStories, formatMessage } from "../../util";
+import { createComponentStories } from "../../util";
 import { asyncPrimaryAction, secondaryAction } from "./Actions.stories";
 
 const { defaultExport, createStory } = createComponentStories({
@@ -15,11 +15,11 @@ export const FillError = createStory({
   primaryAction: asyncPrimaryAction,
   secondaryAction,
   errorBannerWidth: "fill",
-  error: formatMessage("Something went wrong"),
+  error: "Something went wrong",
 });
 
 export const ContentWidthError = createStory({
   primaryAction: asyncPrimaryAction,
   secondaryAction,
-  error: formatMessage("Something went wrong"),
+  error: "Something went wrong",
 });

--- a/packages/storybook/stories/Components/Actions/ActionsSpaceBetween.stories.tsx
+++ b/packages/storybook/stories/Components/Actions/ActionsSpaceBetween.stories.tsx
@@ -1,5 +1,5 @@
 import { SpaceBetweenActions } from "../..";
-import { createComponentStories, formatMessage } from "../../util";
+import { createComponentStories } from "../../util";
 import { asyncPrimaryAction, secondaryAction } from "./Actions.stories";
 
 const { defaultExport, createStory } = createComponentStories({
@@ -15,11 +15,11 @@ export const FillError = createStory({
   primaryAction: asyncPrimaryAction,
   secondaryAction,
   errorBannerWidth: "fill",
-  error: formatMessage("Something went wrong"),
+  error: "Something went wrong",
 });
 
 export const ContentWidthError = createStory({
   primaryAction: asyncPrimaryAction,
   secondaryAction,
-  error: formatMessage("Something went wrong"),
+  error: "Something went wrong",
 });

--- a/packages/storybook/stories/Components/AreaLoader.stories.tsx
+++ b/packages/storybook/stories/Components/AreaLoader.stories.tsx
@@ -1,5 +1,5 @@
 import { Body, Box, Card, AreaLoader, Stack, Title, Inset } from "../";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 import { Story } from "@storybook/react";
 import { useArgs } from "@storybook/addons";
 import { useEffect } from "react";
@@ -20,8 +20,8 @@ InCard.decorators = [
       <Box position="relative">
         <Inset space={24}>
           <Stack space={8}>
-            <Title size="large">{formatMessage("Campaign type")}</Title>
-            <Body size="large">{formatMessage("Drive-traffic advanced")}</Body>
+            <Title size="large">Campaign type</Title>
+            <Body size="large">Drive-traffic advanced</Body>
           </Stack>
         </Inset>
         <Story />

--- a/packages/storybook/stories/Components/Banner.stories.tsx
+++ b/packages/storybook/stories/Components/Banner.stories.tsx
@@ -1,4 +1,4 @@
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 import { Banner } from "../";
 import { action } from "@storybook/addon-actions";
 
@@ -13,14 +13,14 @@ const { defaultExport, createStory } = createComponentStories({
 
 export default defaultExport;
 
-const title = formatMessage("Title");
-const shortDescription = formatMessage("Description");
-const longDescription = formatMessage(`Extensively long description, this is so big that it
+const title = "Title";
+const shortDescription = "Description";
+const longDescription = `Extensively long description, this is so big that it
 should overfill the screen and break into several lines. It's really a long description, not gonna lie.
 Extensively long description, this is so big that it
 should overfill the screen and break into several lines. It's really a long description, not gonna lie.
 Extensively long description, this is so big that it
-should overfill the screen and break into several lines. It's really a long description, not gonna lie.`);
+should overfill the screen and break into several lines. It's really a long description, not gonna lie.`;
 
 export const Dismissable = createStory({
   kind: "informative",
@@ -33,7 +33,7 @@ export const DismissableWithAction = createStory({
   title,
   description: shortDescription,
   action: {
-    label: formatMessage("Close"),
+    label: "Close",
     onPress: action("onAction"),
   },
 });

--- a/packages/storybook/stories/Components/Breadcrumb.stories.tsx
+++ b/packages/storybook/stories/Components/Breadcrumb.stories.tsx
@@ -1,4 +1,4 @@
-import { Breadcrumb, unsafeLocalizedString } from "../";
+import { Breadcrumb } from "..";
 import { createComponentStories } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
@@ -11,27 +11,27 @@ export default defaultExport;
 export const breadcrumb = createStory({
   items: [
     {
-      label: unsafeLocalizedString("Root"),
+      label: "Root",
       href: "https://www.example.com",
     },
     {
-      label: unsafeLocalizedString("1st Level"),
+      label: "1st Level",
       href: "https://www.example.com",
     },
     {
-      label: unsafeLocalizedString("2nd Level"),
+      label: "2nd Level",
       href: "https://www.example.com",
     },
     {
-      label: unsafeLocalizedString("3rd Level"),
+      label: "3rd Level",
       href: "https://www.example.com",
     },
     {
-      label: unsafeLocalizedString("4th Level"),
+      label: "4th Level",
       href: "https://www.example.com",
     },
     {
-      label: unsafeLocalizedString("5th Level"),
+      label: "5th Level",
     },
   ],
 });

--- a/packages/storybook/stories/Components/Button.stories.tsx
+++ b/packages/storybook/stories/Components/Button.stories.tsx
@@ -1,10 +1,10 @@
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 import { Button, IconCheck } from "../";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Button,
   args: {
-    label: formatMessage("Button"),
+    label: "Button",
   },
   argTypes: {
     label: textArgType,

--- a/packages/storybook/stories/Components/ButtonLink.stories.tsx
+++ b/packages/storybook/stories/Components/ButtonLink.stories.tsx
@@ -1,11 +1,11 @@
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 import { ButtonLink } from "../";
 import { IconCheck } from "@buildo/bento-design-system";
 
 const { defaultExport, createStory } = createComponentStories({
   component: ButtonLink,
   args: {
-    label: formatMessage("Button"),
+    label: "Button",
     href: "https://google.com",
     target: "blank",
   },

--- a/packages/storybook/stories/Components/Card.stories.tsx
+++ b/packages/storybook/stories/Components/Card.stories.tsx
@@ -1,4 +1,4 @@
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 import { Body, Card, Stack, Title } from "../";
 import { unconditionalProperties, vars } from "@buildo/bento-design-system";
 
@@ -64,8 +64,8 @@ export default defaultExport;
 export const card = createStory({
   children: (
     <Stack space={8}>
-      <Title size="large">{formatMessage("Campaign type")}</Title>
-      <Body size="large">{formatMessage("Drive-traffic advanced")}</Body>
+      <Title size="large">Campaign type</Title>
+      <Body size="large">Drive-traffic advanced</Body>
     </Stack>
   ),
 });

--- a/packages/storybook/stories/Components/Checkbox.stories.tsx
+++ b/packages/storybook/stories/Components/Checkbox.stories.tsx
@@ -1,10 +1,10 @@
 import { Body, Box, Card, Checkbox, Column, Columns, Stack, Title } from "..";
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 
 const { defaultExport, createControlledStory } = createComponentStories({
   component: Checkbox,
   args: {
-    "aria-label": formatMessage("Toggle card selection"),
+    "aria-label": "Toggle card selection",
   },
   argTypes: {
     label: textArgType,
@@ -18,11 +18,14 @@ const { defaultExport, createControlledStory } = createComponentStories({
               <Story />
             </Column>
             <Stack space={8}>
-              <Title size="medium">{formatMessage("Selectable card")}</Title>
+              <Title size="medium">Selectable card</Title>
               <Body size="medium">
-                {formatMessage(
-                  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-                )}
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+                exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+                irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+                pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+                deserunt mollit anim id est laborum.
               </Body>
             </Stack>
           </Columns>

--- a/packages/storybook/stories/Components/CheckboxField.stories.tsx
+++ b/packages/storybook/stories/Components/CheckboxField.stories.tsx
@@ -1,10 +1,10 @@
 import { CheckboxField } from "../";
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 
 const { defaultExport, createControlledStory } = createComponentStories({
   component: CheckboxField,
   args: {
-    label: formatMessage("I agree with the terms and conditions"),
+    label: "I agree with the terms and conditions",
     name: "terms-and-conditions",
   },
   argTypes: {
@@ -19,7 +19,7 @@ export const Unchecked = createControlledStory(false, {});
 export const Checked = createControlledStory(true, {});
 
 export const Error = createControlledStory(false, {
-  issues: [formatMessage("This field is required")],
+  issues: ["This field is required"],
 });
 
 export const Disabled = createControlledStory(false, {
@@ -27,7 +27,6 @@ export const Disabled = createControlledStory(false, {
 });
 
 export const LongLabel = createControlledStory(false, {
-  label: formatMessage(
-    "Very very very very very very very very long label. Did I say this label is very long? Well let me say it again, it's loooooong, very looooooooong. Maybe we should say it again, let's go! Very very very very very very very very long label."
-  ),
+  label:
+    "Very very very very very very very very long label. Did I say this label is very long? Well let me say it again, it's loooooong, very looooooooong. Maybe we should say it again, let's go! Very very very very very very very very long label.",
 });

--- a/packages/storybook/stories/Components/CheckboxGroupField.stories.tsx
+++ b/packages/storybook/stories/Components/CheckboxGroupField.stories.tsx
@@ -1,29 +1,29 @@
 import { CheckboxGroupField } from "../";
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 
 const { defaultExport, createControlledStory } = createComponentStories({
   component: CheckboxGroupField,
   args: {
-    label: formatMessage("What are your favourite colors?"),
+    label: "What are your favourite colors?",
     orientation: "vertical",
-    assistiveText: formatMessage("You can select multiple options"),
+    assistiveText: "You can select multiple options",
     options: [
       {
         value: "blue",
-        label: formatMessage("Blue"),
+        label: "Blue",
       },
       {
         value: "green",
-        label: formatMessage("Green"),
+        label: "Green",
       },
       {
         value: "pink",
-        label: formatMessage("Pink"),
+        label: "Pink",
         isDisabled: true,
       },
       {
         value: "red",
-        label: formatMessage("Red"),
+        label: "Red",
       },
     ],
   },
@@ -39,5 +39,5 @@ export const Vertical = createControlledStory([], {});
 export const Horizontal = createControlledStory([], { orientation: "horizontal" });
 
 export const Error = createControlledStory([], {
-  issues: [formatMessage("Select at least 1 option")],
+  issues: ["Select at least 1 option"],
 });

--- a/packages/storybook/stories/Components/Chip.stories.tsx
+++ b/packages/storybook/stories/Components/Chip.stories.tsx
@@ -1,11 +1,11 @@
 import { IconPlaceholder } from "@buildo/bento-design-system";
 import { Chip } from "../";
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Chip,
   args: {
-    label: formatMessage("Label"),
+    label: "Label",
   },
   argTypes: {
     label: textArgType,

--- a/packages/storybook/stories/Components/ContentWithSidebar.stories.tsx
+++ b/packages/storybook/stories/Components/ContentWithSidebar.stories.tsx
@@ -1,10 +1,10 @@
 import { Body, Box, ContentWithSidebar } from "..";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 
 const content = (
   <Box display="flex" height="full" justifyContent="center" alignItems="center">
     <Body key="main" size="large">
-      {formatMessage("Main content")}
+      Main content
     </Body>
   </Box>
 );
@@ -12,7 +12,7 @@ const content = (
 const sidebar = (
   <Box display="flex" height="full" justifyContent="center" alignItems="center">
     <Body key="sidebar" size="large">
-      {formatMessage("Sidebar")}
+      Sidebar
     </Body>
   </Box>
 );

--- a/packages/storybook/stories/Components/DateField.stories.tsx
+++ b/packages/storybook/stories/Components/DateField.stories.tsx
@@ -1,4 +1,4 @@
-import { createComponentStories, formatMessage, fieldArgTypes, textArgType } from "../util";
+import { createComponentStories, fieldArgTypes, textArgType } from "../util";
 import { DateField } from "../";
 import {
   startOfWeek,
@@ -17,10 +17,10 @@ const { defaultExport, createControlledStory } = createComponentStories({
   component: DateField,
   args: {
     name: "date",
-    label: formatMessage("Date"),
-    placeholder: formatMessage("Select a date"),
-    assistiveText: formatMessage("This is your favorite date"),
-    hint: formatMessage("Some hint that is very useful to you"),
+    label: "Date",
+    placeholder: "Select a date",
+    assistiveText: "This is your favorite date",
+    hint: "Some hint that is very useful to you",
   },
   argTypes: {
     ...fieldArgTypes,
@@ -51,7 +51,7 @@ const inOneWeek = addWeeks(today, 1);
 export const SingleWithMinMax = createControlledStory(null, {
   minDate: today,
   maxDate: inOneWeek,
-  assistiveText: formatMessage("You can select a date between today and one week from now"),
+  assistiveText: "You can select a date between today and one week from now",
 });
 
 const inOneMonth = addMonths(today, 1);
@@ -59,21 +59,21 @@ export const RangeWithMinMax = createControlledStory([null, null], {
   type: "range",
   minDate: today,
   maxDate: inOneMonth,
-  assistiveText: formatMessage("You can select a date between today and one month from now"),
+  assistiveText: "You can select a date between today and one month from now",
 });
 
 export const SingleWithShortcuts = createControlledStory(null, {
   shortcuts: [
     {
-      label: formatMessage("Today"),
+      label: "Today",
       value: new Date(),
     },
     {
-      label: formatMessage("In a week"),
+      label: "In a week",
       value: inOneWeek,
     },
     {
-      label: formatMessage("In a month"),
+      label: "In a month",
       value: inOneMonth,
     },
   ],
@@ -83,15 +83,15 @@ export const RangeWithShortcuts = createControlledStory([null, null], {
   type: "range",
   shortcuts: [
     {
-      label: formatMessage("This Week"),
+      label: "This Week",
       value: [startOfWeek(today), endOfWeek(today)],
     },
     {
-      label: formatMessage("This Month"),
+      label: "This Month",
       value: [startOfMonth(today), endOfMonth(today)],
     },
     {
-      label: formatMessage("This Year"),
+      label: "This Year",
       value: [startOfYear(today), endOfYear(today)],
     },
   ],

--- a/packages/storybook/stories/Components/Disclosure.stories.tsx
+++ b/packages/storybook/stories/Components/Disclosure.stories.tsx
@@ -1,11 +1,11 @@
 import { Card, Disclosure, Placeholder } from "../";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 import { Story } from "@storybook/react";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Disclosure,
   args: {
-    title: formatMessage("Title"),
+    title: "Title",
     children: <Placeholder />,
   },
   argTypes: {},

--- a/packages/storybook/stories/Components/DisclosureGroup.stories.tsx
+++ b/packages/storybook/stories/Components/DisclosureGroup.stories.tsx
@@ -1,5 +1,5 @@
 import { DisclosureGroup, Placeholder } from "..";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: DisclosureGroup,
@@ -12,16 +12,16 @@ export default defaultExport;
 export const Linear = createStory({
   items: [
     {
-      title: formatMessage("Title"),
+      title: "Title",
       children: <Placeholder />,
     },
     {
-      title: formatMessage("Title"),
+      title: "Title",
       children: <Placeholder />,
       initialIsOpen: true,
     },
     {
-      title: formatMessage("Title"),
+      title: "Title",
       children: <Placeholder />,
     },
   ],
@@ -29,26 +29,26 @@ export const Linear = createStory({
 
 const nestedItems = [
   {
-    title: formatMessage("Title"),
+    title: "Title",
     initialIsOpen: true,
     items: [
       {
-        title: formatMessage("Title"),
+        title: "Title",
         children: <Placeholder />,
         initialIsOpen: true,
       },
       {
-        title: formatMessage("Title"),
+        title: "Title",
         children: <Placeholder />,
       },
     ],
   },
   {
-    title: formatMessage("Title"),
+    title: "Title",
     children: <Placeholder />,
   },
   {
-    title: formatMessage("Title"),
+    title: "Title",
     children: <Placeholder />,
   },
 ];

--- a/packages/storybook/stories/Components/Feedback.stories.tsx
+++ b/packages/storybook/stories/Components/Feedback.stories.tsx
@@ -1,11 +1,11 @@
 import { action } from "@storybook/addon-actions";
 import { Feedback, IllustrationIdea } from "..";
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Feedback,
   args: {
-    title: formatMessage("Title"),
+    title: "Title",
     status: "positive",
     size: "large",
   },
@@ -26,54 +26,53 @@ export const Negative = createStory({
 });
 
 export const TitleAndDescription = createStory({
-  description: formatMessage("Description"),
+  description: "Description",
 });
 
 export const TitleAndButton = createStory({
   action: {
     onPress: action("On click"),
-    label: formatMessage("Click here"),
+    label: "Click here",
   },
 });
 
 export const TitleDescriptionAndButton = createStory({
-  description: formatMessage("Description"),
+  description: "Description",
   action: {
     onPress: action("On click"),
-    label: formatMessage("Click here"),
+    label: "Click here",
   },
 });
 
 export const WrappingTitleAndDescription = createStory({
-  title: formatMessage("Very long title that wraps to the next line"),
-  description: formatMessage(
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-  ),
+  title: "Very long title that wraps to the next line",
+  description:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
 });
 
 export const Background = createStory({
-  description: formatMessage("Description"),
+  description: "Description",
   action: {
     onPress: action("On click"),
-    label: formatMessage("Click here"),
+    label: "Click here",
   },
   background: true,
 });
 
 export const CustomIllustration = createStory({
   illustration: IllustrationIdea,
-  description: formatMessage("Description"),
+  description: "Description",
   action: {
     onPress: action("On click"),
-    label: formatMessage("Click here"),
+    label: "Click here",
   },
 });
 
 export const MediumSize = createStory({
   size: "medium",
-  description: formatMessage("Description"),
+  description: "Description",
   action: {
     onPress: action("On click"),
-    label: formatMessage("Click here"),
+    label: "Click here",
   },
 });

--- a/packages/storybook/stories/Components/Form.stories.tsx
+++ b/packages/storybook/stories/Components/Form.stories.tsx
@@ -11,7 +11,7 @@ import {
   RadioGroupField,
   Omit,
 } from "..";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Form,
@@ -30,12 +30,12 @@ const ExampleTextField = (
   const [value, onChange] = useState("");
   return (
     <TextField
-      placeholder={formatMessage("Insert a value")}
+      placeholder="Insert a value"
       value={value}
       onChange={onChange}
       onBlur={() => {}}
       name="textField"
-      hint={formatMessage("Some useful advice on how to fill this field")}
+      hint="Some useful advice on how to fill this field"
       {...props}
     />
   );
@@ -50,7 +50,7 @@ const ExampleNumberField = (
   const [value, onChange] = useState<number | undefined>(undefined);
   return (
     <NumberField
-      placeholder={formatMessage("Insert a value")}
+      placeholder="Insert a value"
       value={value}
       onChange={onChange}
       onBlur={() => {}}
@@ -69,7 +69,7 @@ const ExampleSelectField = <A extends {}>(
   const [value, onChange] = useState<A | undefined>(undefined);
   return (
     <SelectField
-      placeholder={formatMessage("Select a value")}
+      placeholder="Select a value"
       value={value}
       onChange={onChange}
       name="selectField"
@@ -96,67 +96,57 @@ const ExampleRadioGroupField = (
 };
 
 export const multipleSections = createStory({
-  title: formatMessage("Sign-up"),
-  description: formatMessage("We will ask you some data in order to sign you up"),
+  title: "Sign-up",
+  description: "We will ask you some data in order to sign you up",
   submitButton: {
     onPress: action("Submit"),
-    label: formatMessage("Sign up"),
+    label: "Sign up",
   },
   secondaryButton: {
     onPress: action("Cancel"),
-    label: formatMessage("Never mind"),
+    label: "Never mind",
   },
   children: [
-    <FormSection title={formatMessage("Personal information")}>
+    <FormSection title="Personal information">
       <FormRow>
-        <ExampleTextField label={formatMessage("First name")} />
-        <ExampleTextField label={formatMessage("Last name")} />
+        <ExampleTextField label="First name" />
+        <ExampleTextField label="Last name" />
       </FormRow>
     </FormSection>,
-    <FormSection
-      title={formatMessage("Address")}
-      description={formatMessage("We need this data for invoicing purposes")}
-    >
+    <FormSection title="Address" description="We need this data for invoicing purposes">
       <FormRow>
-        <ExampleTextField label={formatMessage("Street")} />
-        <ExampleTextField label={formatMessage("Number")} />
+        <ExampleTextField label="Street" />
+        <ExampleTextField label="Number" />
       </FormRow>
       <FormRow>
-        <ExampleTextField label={formatMessage("City")} />
+        <ExampleTextField label="City" />
       </FormRow>
       <FormRow>
-        <ExampleTextField label={formatMessage("Country")} />
+        <ExampleTextField label="Country" />
       </FormRow>
     </FormSection>,
-    <FormSection title={formatMessage("Tell us more about you")}>
+    <FormSection title="Tell us more about you">
       <FormRow>
-        <ExampleNumberField
-          label={formatMessage("Average income")}
-          kind="currency"
-          currency="EUR"
-        />
-        <ExampleNumberField
-          label={formatMessage("% of income spent on candies")}
-          kind="percentage"
-        />
+        <ExampleNumberField label="Average income" kind="currency" currency="EUR" />
+        <ExampleNumberField label="% of income spent on candies" kind="percentage" />
       </FormRow>
       <FormRow>
         <ExampleSelectField
-          label={formatMessage("Select your gender")}
+          label="Select your gender"
           options={[
-            { label: formatMessage("Male"), value: "M", kind: "single-line" },
-            { label: formatMessage("Female"), value: "F", kind: "single-line" },
-            { label: formatMessage("Other"), value: "O", kind: "single-line" },
+            { label: "Male", value: "M", kind: "single-line" },
+            { label: "Female", value: "F", kind: "single-line" },
+            { label: "Other", value: "O", kind: "single-line" },
           ]}
         />
       </FormRow>
       <FormRow>
         <ExampleRadioGroupField
-          label={formatMessage("What's your main income source?")}
+          label={"What's your main income source?"}
           options={[
-            { label: formatMessage("Working"), value: "W" },
-            { label: formatMessage("Inheritance"), value: "I" },
-            { label: formatMessage("Other"), value: "O" },
+            { label: "Working", value: "W" },
+            { label: "Inheritance", value: "I" },
+            { label: "Other", value: "O" },
           ]}
         />
       </FormRow>

--- a/packages/storybook/stories/Components/IconButton.stories.tsx
+++ b/packages/storybook/stories/Components/IconButton.stories.tsx
@@ -1,11 +1,11 @@
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 import { IconButton } from "../";
 import { IconPlaceholder } from "@buildo/bento-design-system";
 
 const { defaultExport, createStory } = createComponentStories({
   component: IconButton,
   args: {
-    label: formatMessage("Button"),
+    label: "Button",
     icon: IconPlaceholder,
     size: 12,
   },

--- a/packages/storybook/stories/Components/InlineLoader.stories.tsx
+++ b/packages/storybook/stories/Components/InlineLoader.stories.tsx
@@ -1,10 +1,10 @@
 import { InlineLoader } from "../";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: InlineLoader,
   args: {
-    message: formatMessage("This may take several minutes..."),
+    message: "This may take several minutes...",
   },
 });
 

--- a/packages/storybook/stories/Components/Link.stories.tsx
+++ b/packages/storybook/stories/Components/Link.stories.tsx
@@ -1,12 +1,12 @@
 import { action } from "@storybook/addon-actions";
 import React from "react";
 import { Body, Box, Label, Link } from "..";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Link,
   args: {
-    label: formatMessage("I'm a link"),
+    label: "I'm a link",
   },
   decorators: [
     (Story: React.FC) => (
@@ -77,7 +77,7 @@ export const ComplexChildren = createStory({
   label: undefined,
   children: (
     <Box background="backgroundPositive" padding={40} borderRadius={16} boxShadow="outlinePositive">
-      <Body size="large">{formatMessage("The entire box is a link!")}</Body>
+      <Body size="large">The entire box is a link!</Body>
     </Box>
   ),
 });

--- a/packages/storybook/stories/Components/List.stories.tsx
+++ b/packages/storybook/stories/Components/List.stories.tsx
@@ -1,4 +1,4 @@
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 import {
   IconInformative,
   IconNegative,
@@ -8,7 +8,7 @@ import {
   svgIllustrationProps,
   IllustrationProps,
   Box,
-} from "../";
+} from "..";
 import { Children } from "@buildo/bento-design-system";
 
 function Illustration(props: IllustrationProps) {
@@ -28,10 +28,9 @@ const { defaultExport, createStory } = createComponentStories({
   argTypes: {},
 });
 
-const label = formatMessage("List item");
-const labelLong = formatMessage(
-  "Exceedingly long list item label that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so. Exceedingly long list item label that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so."
-);
+const label = "List item";
+const labelLong =
+  "Exceedingly long list item label that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so. Exceedingly long list item label that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so.";
 const labelRich = (
   <>
     Hello{" "}
@@ -40,14 +39,12 @@ const labelRich = (
     </Box>
   </>
 ) as Children;
-const secondLine = formatMessage("description");
-const secondLineLong = formatMessage(
-  "Exceedingly long list item descrption that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so. Exceedingly long list item description that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so."
-);
-const overline = formatMessage("Overline");
-const overlineLong = formatMessage(
-  "Exceedingly long overline that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so. Exceedingly long overline that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so."
-);
+const secondLine = "description";
+const secondLineLong =
+  "Exceedingly long list item descrption that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so. Exceedingly long list item description that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so.";
+const overline = "Overline";
+const overlineLong =
+  "Exceedingly long overline that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so. Exceedingly long overline that should wrap to multiple lines. Let's check with a veeeeeeery long long string. Is it working? I hope so.";
 const href = "https://www.example.com";
 
 export default defaultExport;
@@ -68,7 +65,7 @@ export const SingleLineIcon = createStory({
     { kind: "single-line", label, icon: IconWarning, href },
     {
       kind: "single-line",
-      label: formatMessage("Disabled"),
+      label: "Disabled",
       icon: IconCheck,
       disabled: true,
       href,

--- a/packages/storybook/stories/Components/Menu.stories.tsx
+++ b/packages/storybook/stories/Components/Menu.stories.tsx
@@ -2,53 +2,53 @@ import { Body, Title } from "@buildo/bento-design-system";
 import { action } from "@storybook/addon-actions";
 import { ComponentProps } from "react";
 import { Avatar, Box, Button, Menu, Stack } from "..";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 
 const items: ComponentProps<typeof Menu>["items"] = [
   {
-    label: formatMessage("Item 1"),
+    label: "Item 1",
     items: [
-      { label: formatMessage("Sub item 1.1"), onPress: action("Sub item 1.1") },
-      { label: formatMessage("Sub item 1.2"), onPress: action("Sub item 1.2") },
+      { label: "Sub item 1.1", onPress: action("Sub item 1.1") },
+      { label: "Sub item 1.2", onPress: action("Sub item 1.2") },
     ],
   },
   {
-    label: formatMessage("Item 2 (link)"),
+    label: "Item 2 (link)",
     href: "https://www.google.com",
   },
   {
-    label: formatMessage("Item 3"),
+    label: "Item 3",
     onPress: action("Item 3"),
     disabled: true,
   },
   {
-    label: formatMessage("Item 4"),
+    label: "Item 4",
     items: [
       {
-        label: formatMessage("Sub item 4.1"),
+        label: "Sub item 4.1",
         items: [
-          { label: formatMessage("Sub item 4.1.1"), onPress: action("Sub item 4.1.1") },
-          { label: formatMessage("Sub item 4.1.2"), onPress: action("Sub item 4.1.2") },
+          { label: "Sub item 4.1.1", onPress: action("Sub item 4.1.1") },
+          { label: "Sub item 4.1.2", onPress: action("Sub item 4.1.2") },
         ],
       },
-      { label: formatMessage("Sub item 4.2"), onPress: action("Sub item 4.2") },
-      { label: formatMessage("Sub item 4.3"), onPress: action("Sub item 4.3") },
-      { label: formatMessage("Sub item 4.4"), onPress: action("Sub item 4.4") },
-      { label: formatMessage("Sub item 4.5"), onPress: action("Sub item 4.5") },
+      { label: "Sub item 4.2", onPress: action("Sub item 4.2") },
+      { label: "Sub item 4.3", onPress: action("Sub item 4.3") },
+      { label: "Sub item 4.4", onPress: action("Sub item 4.4") },
+      { label: "Sub item 4.5", onPress: action("Sub item 4.5") },
       {
-        label: formatMessage("Sub item 4.6"),
+        label: "Sub item 4.6",
         items: [
-          { label: formatMessage("Sub item 4.6.1"), onPress: action("Sub item 4.6.1") },
-          { label: formatMessage("Sub item 4.6.2"), onPress: action("Sub item 4.6.2") },
+          { label: "Sub item 4.6.1", onPress: action("Sub item 4.6.1") },
+          { label: "Sub item 4.6.2", onPress: action("Sub item 4.6.2") },
         ],
       },
-      { label: formatMessage("Sub item 4.7"), onPress: action("Sub item 4.7") },
-      { label: formatMessage("Sub item 4.8"), onPress: action("Sub item 4.8") },
-      { label: formatMessage("Sub item 4.9"), onPress: action("Sub item 4.9") },
+      { label: "Sub item 4.7", onPress: action("Sub item 4.7") },
+      { label: "Sub item 4.8", onPress: action("Sub item 4.8") },
+      { label: "Sub item 4.9", onPress: action("Sub item 4.9") },
     ],
   },
   {
-    label: formatMessage("Item 5"),
+    label: "Item 5",
     onPress: action("Item 5"),
   },
 ];
@@ -67,12 +67,7 @@ export default defaultExport;
 export const ButtonTrigger = createStory({
   trigger: (ref, triggerProps, { toggle }) => (
     <Box ref={ref} display="inline-block" {...triggerProps}>
-      <Button
-        kind="solid"
-        hierarchy="primary"
-        label={formatMessage("Open menu")}
-        onPress={() => toggle()}
-      />
+      <Button kind="solid" hierarchy="primary" label="Open menu" onPress={() => toggle()} />
     </Box>
   ),
 });
@@ -80,10 +75,10 @@ export const ButtonTrigger = createStory({
 export const AvatarTrigger = createStory({
   header: (
     <Stack space={4}>
-      <Title size="medium">{formatMessage("Jane Doe")}</Title>
-      <Body size="medium">{formatMessage("hello@example.com")}</Body>
+      <Title size="medium">Jane Doe</Title>
+      <Body size="medium">hello@example.com</Body>
       <Body size="small" color="secondary">
-        {formatMessage("Admin")}
+        Admin
       </Body>
     </Stack>
   ),

--- a/packages/storybook/stories/Components/Modal.stories.tsx
+++ b/packages/storybook/stories/Components/Modal.stories.tsx
@@ -1,14 +1,12 @@
 import { Modal, Body, Placeholder, Stack, CustomModal, Feedback, Inset } from "../";
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 import { action } from "@storybook/addon-actions";
 import { screen } from "@storybook/testing-library";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Modal,
   args: {
-    title: formatMessage(
-      "Create item title veeeery very long very long title here do you see how long it is?"
-    ),
+    title: "Create item title veeeery very long very long title here do you see how long it is?",
   },
   argTypes: {
     title: textArgType,
@@ -27,11 +25,11 @@ export default defaultExport;
 export const WithActions = createStory({
   children: [<Placeholder />],
   primaryAction: {
-    label: formatMessage("Create"),
+    label: "Create",
     onPress: action("Create"),
   },
   secondaryAction: {
-    label: formatMessage("Cancel"),
+    label: "Cancel",
     onPress: action("Cancel"),
   },
 });
@@ -47,11 +45,11 @@ export const Scrollable = createStory({
     </Stack>,
   ],
   primaryAction: {
-    label: formatMessage("Create"),
+    label: "Create",
     onPress: action("Create"),
   },
   secondaryAction: {
-    label: formatMessage("Cancel"),
+    label: "Cancel",
     onPress: action("Cancel"),
   },
 });
@@ -59,44 +57,40 @@ export const Scrollable = createStory({
 export const WithError = createStory({
   children: [<Placeholder />],
   primaryAction: {
-    label: formatMessage("Create"),
+    label: "Create",
     onPress: action("Create"),
   },
   secondaryAction: {
-    label: formatMessage("Cancel"),
+    label: "Cancel",
     onPress: action("Cancel"),
   },
-  error: formatMessage("Something went wrong"),
+  error: "Something went wrong",
 });
 
 export const Destructive = createStory({
   kind: "destructive",
-  title: formatMessage("Delete item"),
-  children: (
-    <Body size="medium">{formatMessage("Are you sure you want to delete this item?")}</Body>
-  ),
+  title: "Delete item",
+  children: <Body size="medium">Are you sure you want to delete this item?</Body>,
   primaryAction: {
-    label: formatMessage("Delete"),
+    label: "Delete",
     onPress: action("Delete"),
   },
   secondaryAction: {
-    label: formatMessage("Cancel"),
+    label: "Cancel",
     onPress: action("Cancel"),
   },
 });
 
 export const Warning = createStory({
-  title: formatMessage("Warning"),
+  title: "Warning",
   kind: "warning",
-  children: (
-    <Body size="medium">{formatMessage("Are you sure you want to create this item?")}</Body>
-  ),
+  children: <Body size="medium">Are you sure you want to create this item?</Body>,
   primaryAction: {
-    label: formatMessage("Create"),
+    label: "Create",
     onPress: action("Create"),
   },
   secondaryAction: {
-    label: formatMessage("Cancel"),
+    label: "Cancel",
     onPress: action("Cancel"),
   },
 });
@@ -104,7 +98,7 @@ export const Warning = createStory({
 export const WithAsyncPrimaryAction = createStory({
   children: [<Placeholder />],
   primaryAction: {
-    label: formatMessage("Create new item"),
+    label: "Create new item",
     onPress: () =>
       new Promise((resolve) => {
         setTimeout(() => {
@@ -114,7 +108,7 @@ export const WithAsyncPrimaryAction = createStory({
       }),
   },
   secondaryAction: {
-    label: formatMessage("Cancel"),
+    label: "Cancel",
     onPress: action("Cancel"),
   },
 });
@@ -127,11 +121,11 @@ export const Small = createStory({
   size: "small",
   children: [<Placeholder />],
   primaryAction: {
-    label: formatMessage("Create"),
+    label: "Create",
     onPress: action("Create"),
   },
   secondaryAction: {
-    label: formatMessage("Cancel"),
+    label: "Cancel",
     onPress: action("Cancel"),
   },
 });
@@ -140,11 +134,11 @@ export const Large = createStory({
   size: "large",
   children: [<Placeholder />],
   primaryAction: {
-    label: formatMessage("Create"),
+    label: "Create",
     onPress: action("Create"),
   },
   secondaryAction: {
-    label: formatMessage("Cancel"),
+    label: "Cancel",
     onPress: action("Cancel"),
   },
 });
@@ -153,11 +147,11 @@ export const Wide = createStory({
   size: "wide",
   children: [<Placeholder />],
   primaryAction: {
-    label: formatMessage("Create"),
+    label: "Create",
     onPress: action("Create"),
   },
   secondaryAction: {
-    label: formatMessage("Cancel"),
+    label: "Cancel",
     onPress: action("Cancel"),
   },
 });
@@ -170,9 +164,9 @@ export const Custom = () => {
           <Feedback
             size="medium"
             status="negative"
-            title={formatMessage("Something went wrong")}
-            description={formatMessage("Wait a few minutes and retry")}
-            action={{ label: formatMessage("retry"), onPress: action("onPress") }}
+            title="Something went wrong"
+            description="Wait a few minutes and retry"
+            action={{ label: "retry", onPress: action("onPress") }}
           />
         </Stack>
       </Inset>

--- a/packages/storybook/stories/Components/Navigation.stories.tsx
+++ b/packages/storybook/stories/Components/Navigation.stories.tsx
@@ -1,27 +1,27 @@
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 import { Navigation } from "../";
 import { ComponentProps } from "react";
 import { IconInformative, IllustrationIdea } from "..";
 
 const destinations: ComponentProps<typeof Navigation>["destinations"] = [
   {
-    label: formatMessage("Destination 1"),
+    label: "Destination 1",
     href: "https://google.com",
     target: "_blank",
     active: true,
   },
   {
-    label: formatMessage("Destination 2"),
+    label: "Destination 2",
     href: "https://amazon.com",
     target: "_blank",
   },
   {
-    label: formatMessage("Destination 3"),
+    label: "Destination 3",
     href: "https://apple.com",
     disabled: true,
   },
   {
-    label: formatMessage("Destination 4"),
+    label: "Destination 4",
     href: "https://microsoft.com",
   },
 ];

--- a/packages/storybook/stories/Components/NumberField.stories.tsx
+++ b/packages/storybook/stories/Components/NumberField.stories.tsx
@@ -1,13 +1,13 @@
 import { NumberField } from "../";
-import { createComponentStories, fieldArgTypes, formatMessage, textArgType } from "../util";
+import { createComponentStories, fieldArgTypes, textArgType } from "../util";
 
 const { defaultExport, createStory, createControlledStory } = createComponentStories({
   component: NumberField,
   args: {
     name: "applications",
-    label: formatMessage("Applications"),
-    placeholder: formatMessage("Number of target applications"),
-    assistiveText: formatMessage("The number of applications this campaign is targeting"),
+    label: "Applications",
+    placeholder: "Number of target applications",
+    assistiveText: "The number of applications this campaign is targeting",
   },
   argTypes: {
     ...fieldArgTypes,
@@ -24,7 +24,7 @@ export const Disabled = createControlledStory(0, {
 });
 
 export const Error = createControlledStory(0, {
-  issues: [formatMessage("Please insert a number greater than 2")],
+  issues: ["Please insert a number greater than 2"],
 });
 
 export const Currency = createControlledStory(0, {

--- a/packages/storybook/stories/Components/Popover.stories.tsx
+++ b/packages/storybook/stories/Components/Popover.stories.tsx
@@ -1,7 +1,7 @@
 import { Story } from "@storybook/react";
 import { ComponentProps, useRef, useState } from "react";
 import { Box, Button, Placeholder, Popover } from "..";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 
 const { defaultExport } = createComponentStories({
   component: Popover,
@@ -32,7 +32,7 @@ popover.decorators = [
         <Button
           kind="solid"
           hierarchy="primary"
-          label={formatMessage(`${isOpen ? "Close" : "Open"} popover`)}
+          label={`${isOpen ? "Close" : "Open"} popover`}
           onPress={() => setIsOpen(!isOpen)}
         />
         {story({

--- a/packages/storybook/stories/Components/RadioGroupField.stories.tsx
+++ b/packages/storybook/stories/Components/RadioGroupField.stories.tsx
@@ -1,31 +1,30 @@
-import { createComponentStories, fieldArgTypes, formatMessage } from "../util";
+import { createComponentStories, fieldArgTypes } from "../util";
 import { RadioGroupField } from "..";
 
 const { defaultExport, createControlledStory } = createComponentStories({
   component: RadioGroupField,
   args: {
-    label: formatMessage("Budget options"),
+    label: "Budget options",
     name: "budgetOptions",
-    assistiveText: formatMessage("Assistive Text"),
+    assistiveText: "Assistive Text",
     options: [
       {
         value: "unlimited",
-        label: formatMessage("Unlimited"),
+        label: "Unlimited",
       },
       {
         value: 2,
-        label: formatMessage("Monthly"),
+        label: "Monthly",
       },
       {
         value: "yearly",
-        label: formatMessage("Yearly"),
+        label: "Yearly",
         isDisabled: true,
       },
       {
         value: false,
-        label: formatMessage(
-          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-        ),
+        label:
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
       },
     ],
   },

--- a/packages/storybook/stories/Components/ReadonlyField.stories.tsx
+++ b/packages/storybook/stories/Components/ReadonlyField.stories.tsx
@@ -1,14 +1,12 @@
 import { ReadOnlyField } from "..";
-import { createComponentStories, fieldArgTypes, formatMessage } from "../util";
+import { createComponentStories, fieldArgTypes } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: ReadOnlyField,
   args: {
     name: "nickname",
-    label: formatMessage("Nickname"),
-    assistiveText: formatMessage(
-      "Your nickname is the name people commonly use to informally refer to you"
-    ),
+    label: "Nickname",
+    assistiveText: "Your nickname is the name people commonly use to informally refer to you",
     value: "myNickname",
   },
   argTypes: {

--- a/packages/storybook/stories/Components/SearchBar.stories.tsx
+++ b/packages/storybook/stories/Components/SearchBar.stories.tsx
@@ -1,11 +1,11 @@
 import { SearchBar } from "../";
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 
 const { defaultExport, createControlledStory } = createComponentStories({
   component: SearchBar,
   args: {
-    "aria-label": formatMessage("Search for anything"),
-    placeholder: formatMessage("Search for anything"),
+    "aria-label": "Search for anything",
+    placeholder: "Search for anything",
   },
   argTypes: {
     placeholder: textArgType,

--- a/packages/storybook/stories/Components/SelectField.stories.tsx
+++ b/packages/storybook/stories/Components/SelectField.stories.tsx
@@ -8,7 +8,7 @@ import {
   svgIllustrationProps,
   BentoConfigProvider,
 } from "../";
-import { createComponentStories, fieldArgTypes, formatMessage, textArgType } from "../util";
+import { createComponentStories, fieldArgTypes, textArgType } from "../util";
 
 function Illustration(props: IllustrationProps) {
   return (
@@ -23,40 +23,40 @@ const { defaultExport, createStory, createControlledStory } = createComponentSto
   args: {
     menuSize: "large",
     name: "color",
-    label: formatMessage("What's your favorite color?"),
-    placeholder: formatMessage("Select a color"),
+    label: "What's your favorite color?",
+    placeholder: "Select a color",
     options: [
       {
         value: 1,
-        label: formatMessage("Red"),
+        label: "Red",
         kind: "two-line",
-        secondLine: formatMessage("prova"),
+        secondLine: "prova",
         illustration: Illustration,
       },
       {
         value: 2,
-        label: formatMessage("Blue"),
+        label: "Blue",
         kind: "two-line",
-        secondLine: formatMessage("prova"),
+        secondLine: "prova",
         illustration: Illustration,
       },
       {
         value: 3,
-        label: formatMessage("Green"),
+        label: "Green",
         kind: "two-line",
-        secondLine: formatMessage("prova"),
+        secondLine: "prova",
         illustration: Illustration,
         disabled: true,
       },
       {
         value: 4,
-        label: formatMessage(`
+        label: `
           Very very very very very very very very long label. Did I say this label is very long? Well let me say it again, it's loooooong, very looooooooong. Maybe we should say it again, let's go! Very very very very very very very very long label.
-          Very very very very very very very very long label. Did I say this label is very long? Well let me say it again, it's loooooong, very looooooooong. Maybe we should say it again, let's go! Very very very very very very very very long label.`),
+          Very very very very very very very very long label. Did I say this label is very long? Well let me say it again, it's loooooong, very looooooooong. Maybe we should say it again, let's go! Very very very very very very very very long label.`,
         kind: "single-line",
       },
     ],
-    noOptionsMessage: formatMessage("No options"),
+    noOptionsMessage: "No options",
   },
   argTypes: {
     ...fieldArgTypes,
@@ -75,19 +75,15 @@ export const Disabled = createControlledStory(undefined, {
 });
 
 export const Error = createControlledStory(undefined, {
-  issues: [formatMessage("Please select a color")],
+  issues: ["Please select a color"],
 });
 
 export const InModal = createControlledStory(undefined, {
-  hint: formatMessage("Something useful"),
+  hint: "Something useful",
 });
 InModal.decorators = [
   (Story: StoryFn) => (
-    <Modal
-      title={formatMessage("Title")}
-      onClose={() => {}}
-      closeButtonLabel={formatMessage("Close")}
-    >
+    <Modal title="Title" onClose={() => {}} closeButtonLabel="Close">
       <Story />
     </Modal>
   ),
@@ -96,28 +92,28 @@ InModal.decorators = [
 export const MultiSelectOneOptionSelected = createControlledStory([1], {
   isMulti: true,
   multiValueMessage: (numberOfSelectedOptions: number) =>
-    formatMessage(`${numberOfSelectedOptions} options selected`),
+    `${numberOfSelectedOptions} options selected`,
   showMultiSelectBulkActions: true,
 });
 
 export const MultiSelectMultipleOptionsSelected = createControlledStory([1, 2], {
   isMulti: true,
   multiValueMessage: (numberOfSelectedOptions: number) =>
-    formatMessage(`${numberOfSelectedOptions} options selected`),
+    `${numberOfSelectedOptions} options selected`,
 });
 
 export const WithIconSelected = createControlledStory(1, {
   options: [
-    { value: 1, label: formatMessage("Idea"), icon: IconIdea },
-    { value: 2, label: formatMessage("User"), icon: IconUser },
+    { value: 1, label: "Idea", icon: IconIdea },
+    { value: 2, label: "User", icon: IconUser },
   ],
 });
 
 export const ReadOnly = createStory({
   value: 1,
   options: [
-    { value: 1, label: formatMessage("Idea"), icon: IconIdea },
-    { value: 2, label: formatMessage("User"), icon: IconUser },
+    { value: 1, label: "Idea", icon: IconIdea },
+    { value: 2, label: "User", icon: IconUser },
   ],
   isReadOnly: true,
 });

--- a/packages/storybook/stories/Components/SliderField.stories.tsx
+++ b/packages/storybook/stories/Components/SliderField.stories.tsx
@@ -1,5 +1,5 @@
 import { SliderField, SliderFieldProps, Omit } from "..";
-import { Actions, createComponentStories, formatMessage } from "../util";
+import { Actions, createComponentStories } from "../util";
 import { Parameters } from "@storybook/addons";
 import { ComponentStory } from "@storybook/react";
 
@@ -7,8 +7,8 @@ const args = {
   name: "slider-field",
   minValue: 0,
   maxValue: 100,
-  label: formatMessage("Label"),
-  hint: formatMessage("Some hint that is very useful to you"),
+  label: "Label",
+  hint: "Some hint that is very useful to you",
 } as const;
 
 const { defaultExport, createControlledStory: createControlledStory_ } = createComponentStories<
@@ -33,7 +33,7 @@ export default defaultExport;
 
 export const Single = createControlledStory(30, {
   type: "single",
-  assistiveText: formatMessage("Assistive text"),
+  assistiveText: "Assistive text",
 });
 
 export const Double = createControlledStory([30, 80], {

--- a/packages/storybook/stories/Components/Stepper.stories.tsx
+++ b/packages/storybook/stories/Components/Stepper.stories.tsx
@@ -1,5 +1,5 @@
-import { Stepper } from "../";
-import { createComponentStories, formatMessage } from "../util";
+import { Stepper } from "..";
+import { createComponentStories } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Stepper,
@@ -11,10 +11,10 @@ export default defaultExport;
 export const stepper = createStory({
   currentStep: 2,
   steps: [
-    { label: formatMessage("Step 1") },
-    { label: formatMessage("Step 2") },
-    { label: formatMessage("Step 3") },
-    { label: formatMessage("Step 4") },
-    { label: formatMessage("Step 5") },
+    { label: "Step 1" },
+    { label: "Step 2" },
+    { label: "Step 3" },
+    { label: "Step 4" },
+    { label: "Step 5" },
   ],
 });

--- a/packages/storybook/stories/Components/Switch.stories.tsx
+++ b/packages/storybook/stories/Components/Switch.stories.tsx
@@ -1,10 +1,10 @@
 import { Switch } from "../";
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { createComponentStories, textArgType } from "../util";
 
 const { defaultExport, createControlledStory } = createComponentStories({
   component: Switch,
   args: {
-    label: formatMessage("Label"),
+    label: "Label",
     name: "switch-label",
   },
   argTypes: { label: textArgType },
@@ -21,9 +21,8 @@ export const UncheckedDisabled = createControlledStory(false, { disabled: true }
 export const CheckedDisabled = createControlledStory(true, { disabled: true });
 
 export const LongLabel = createControlledStory(false, {
-  label: formatMessage(
-    "Very very very very very very very very long label. Did I say this label is very long? Well let me say it again, it's loooooong, very looooooooong. Maybe we should say it again, let's go! Very very very very very very very very long label."
-  ),
+  label:
+    "Very very very very very very very very long label. Did I say this label is very long? Well let me say it again, it's loooooong, very looooooooong. Maybe we should say it again, let's go! Very very very very very very very very long label.",
 });
 
 export const TrailingSwitch = createControlledStory(true, {

--- a/packages/storybook/stories/Components/Table.stories.tsx
+++ b/packages/storybook/stories/Components/Table.stories.tsx
@@ -10,7 +10,7 @@ import {
   IconWarning,
   NumberField,
 } from "../";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 import orderBy from "lodash.orderby";
 import { IconClose } from "@buildo/bento-design-system";
 import { action } from "@storybook/addon-actions";
@@ -25,59 +25,59 @@ export default defaultExport;
 
 const exampleColumns = [
   tableColumn.button({
-    headerLabel: formatMessage("Button"),
+    headerLabel: "Button",
     accessor: "button",
     sticky: "left",
     disableSortBy: true,
     align: "center",
   }),
   tableColumn.text({
-    headerLabel: formatMessage("Name"),
+    headerLabel: "Name",
     accessor: "name",
   }),
   tableColumn.text({
-    headerLabel: formatMessage("Extended address"),
+    headerLabel: "Extended address",
     accessor: "address",
     width: { custom: 200 },
   }),
   tableColumn.textWithIcon({
-    headerLabel: formatMessage("Country"),
+    headerLabel: "Country",
     accessor: "country",
     iconPosition: "right",
-    hint: formatMessage("This is a hint"),
+    hint: "This is a hint",
   }),
   tableColumn.number({
-    headerLabel: formatMessage("Applications"),
+    headerLabel: "Applications",
     accessor: "applications",
-    valueFormatter: (value) => formatMessage(Intl.NumberFormat("en").format(value)),
+    valueFormatter: (value) => Intl.NumberFormat("en").format(value),
     align: "right",
     hint: { onPress: action("hint") },
   }),
   tableColumn.numberWithIcon({
-    headerLabel: formatMessage("Value"),
+    headerLabel: "Value",
     accessor: "value",
-    valueFormatter: (value) => formatMessage(Intl.NumberFormat("en").format(value)),
+    valueFormatter: (value) => Intl.NumberFormat("en").format(value),
     align: "right",
   }),
   tableColumn.label({
-    headerLabel: formatMessage("Type"),
+    headerLabel: "Type",
     accessor: "type",
   }),
   tableColumn.link({
-    headerLabel: formatMessage("Website"),
+    headerLabel: "Website",
     accessor: "website",
   }),
   tableColumn.icon({
-    headerLabel: formatMessage("Alerts"),
+    headerLabel: "Alerts",
     accessor: "alerts",
   }),
   tableColumn.chip({
-    headerLabel: formatMessage("Status"),
+    headerLabel: "Status",
     accessor: "status",
     align: "center",
   }),
   tableColumn.iconButton({
-    headerLabel: formatMessage("Actions"),
+    headerLabel: "Actions",
     accessor: "deleteAction",
     align: "center",
     disableSortBy: true,
@@ -85,131 +85,131 @@ const exampleColumns = [
 ];
 
 const deleteAction = {
-  label: formatMessage("Delete"),
+  label: "Delete",
   icon: IconClose,
   onPress: () => {},
 };
 
 const exampleData = [
   {
-    name: formatMessage("Amazon"),
+    name: "Amazon",
     address: "Theodore Lowe Ap #867-859 Sit Rd. Azusa New York 39531",
     country: {
       icon: IconInformative,
-      text: formatMessage("US"),
-      tooltipContent: formatMessage("United States"),
+      text: "US",
+      tooltipContent: "United States",
     },
     button: {
-      label: formatMessage("Row 1"),
+      label: "Row 1",
       kind: "transparent",
       hierarchy: "primary",
       onPress: () => {},
     } as const,
-    status: { label: formatMessage("Active"), color: "green" } as const,
+    status: { label: "Active", color: "green" } as const,
     value: {
       numericValue: 100,
       icon: IconInformative,
     },
-    type: formatMessage("Private"),
-    website: { href: "http://www.amazon.com", label: formatMessage("Link") },
-    alerts: { icon: IconWarning, label: formatMessage("Warning") },
-    group: formatMessage("Group 1"),
+    type: "Private",
+    website: { href: "http://www.amazon.com", label: "Link" },
+    alerts: { icon: IconWarning, label: "Warning" },
+    group: "Group 1",
     deleteAction,
   },
   {
-    name: formatMessage("Google"),
+    name: "Google",
     address: "Cecilia Chapman 711-2880 Nulla St.  Mankato Mississippi 96522",
     country: {
       icon: IconInformative,
-      text: formatMessage("US"),
-      tooltipContent: formatMessage("United States"),
+      text: "US",
+      tooltipContent: "United States",
     },
     button: {
-      label: formatMessage("Row 2"),
+      label: "Row 2",
       kind: "transparent",
       hierarchy: "primary",
       onPress: () => {},
     } as const,
     applications: 10_000,
-    status: { label: formatMessage("Paused"), color: "blue" } as const,
+    status: { label: "Paused", color: "blue" } as const,
     value: {
       numericValue: 150,
       icon: IconInformative,
     },
-    type: formatMessage("Private"),
-    website: { href: "http://www.google.com", label: formatMessage("Link") },
-    group: formatMessage("Group 2"),
+    type: "Private",
+    website: { href: "http://www.google.com", label: "Link" },
+    group: "Group 2",
     deleteAction,
   },
   {
-    name: formatMessage("Microsoft"),
+    name: "Microsoft",
     address: "Iris Watson P.O. Box 283 8562 Fusce Rd.  Frederick Nebraska 20620",
     country: {
       icon: IconInformative,
-      text: formatMessage("US"),
-      tooltipContent: formatMessage("United States"),
+      text: "US",
+      tooltipContent: "United States",
     },
     button: {
-      label: formatMessage("Row 3"),
+      label: "Row 3",
       kind: "transparent",
       hierarchy: "primary",
       onPress: () => {},
     } as const,
     applications: 1_000,
-    status: { label: formatMessage("Pending"), color: "yellow" } as const,
+    status: { label: "Pending", color: "yellow" } as const,
     value: {
       numericValue: 120,
       icon: IconInformative,
     },
-    type: formatMessage("Private"),
-    website: { href: "http://www.microsoft.com", label: formatMessage("Link") },
-    alerts: { icon: IconWarning, label: formatMessage("Warning") },
-    group: formatMessage("Group 1"),
+    type: "Private",
+    website: { href: "http://www.microsoft.com", label: "Link" },
+    alerts: { icon: IconWarning, label: "Warning" },
+    group: "Group 1",
     deleteAction,
   },
   {
-    name: formatMessage("buildo"),
+    name: "buildo",
     address: "Celeste Slater 606-3727 Ullamcorper. Street Roseville NH 11523",
     country: {
       icon: null,
-      text: formatMessage("IT"),
+      text: "IT",
     },
     button: {
-      label: formatMessage("Row 4"),
+      label: "Row 4",
       kind: "transparent",
       hierarchy: "primary",
       onPress: () => {},
     } as const,
     applications: 1_200,
-    status: { label: formatMessage("Active"), color: "green" } as const,
-    type: formatMessage("Private"),
-    website: { href: "http://www.buildo.io", label: formatMessage("Link") },
-    group: formatMessage("Group 2"),
+    status: { label: "Active", color: "green" } as const,
+    type: "Private",
+    website: { href: "http://www.buildo.io", label: "Link" },
+    group: "Group 2",
     deleteAction,
   },
   {
-    name: formatMessage("Twitter"),
+    name: "Twitter",
     address: "Theodore Lowe Ap #867-859 Sit Rd. Azusa New York 39531",
     country: {
       icon: IconInformative,
-      text: formatMessage("US"),
-      tooltipContent: formatMessage("United States"),
+      text: "US",
+      tooltipContent: "United States",
     },
     button: {
-      label: formatMessage("Row 5"),
+      label: "Row 5",
       kind: "transparent",
       hierarchy: "primary",
       onPress: () => {},
     } as const,
     applications: 12_000,
-    status: { label: formatMessage("Paused"), color: "blue" } as const,
+    status: { label: "Paused", color: "blue" } as const,
     value: {
       numericValue: 137,
       icon: IconInformative,
     },
-    type: formatMessage("Private"),
-    website: { href: "http://www.twitter.com", label: formatMessage("Link") },
-    group: formatMessage("Group 1"),
+    type: "Private",
+    website: { href: "http://www.twitter.com", label: "Link" },
+    group: "Group 1",
     deleteAction,
   },
 ];
@@ -231,9 +231,9 @@ export const WithFilter = (_args: Parameters<typeof createStory>[0]) => {
   }
 
   const statusOptions = [
-    { label: formatMessage("Active"), value: "Active" } as const,
-    { label: formatMessage("Paused"), value: "Paused" } as const,
-    { label: formatMessage("Pending"), value: "Pending" } as const,
+    { label: "Active", value: "Active" } as const,
+    { label: "Paused", value: "Paused" } as const,
+    { label: "Pending", value: "Pending" } as const,
   ];
   type Status = typeof statusOptions[number]["value"];
 
@@ -254,16 +254,16 @@ export const WithFilter = (_args: Parameters<typeof createStory>[0]) => {
         <TextField
           name="name"
           onBlur={() => {}}
-          label={formatMessage("Name")}
-          placeholder={formatMessage("Search by name")}
+          label="Name"
+          placeholder="Search by name"
           value={nameFilter}
           onChange={setNameFilter}
         />
         <SelectField
           name="status"
           onBlur={() => {}}
-          label={formatMessage("Status")}
-          placeholder={formatMessage("Select a status to filter")}
+          label="Status"
+          placeholder="Select a status to filter"
           value={statusFilter}
           onChange={setStatusFilter}
           options={statusOptions}
@@ -308,8 +308,8 @@ export const WithControlledSorting = (_args: Parameters<typeof createStory>[0]) 
         <NumberField
           name="numberOfRows"
           onBlur={() => {}}
-          label={formatMessage("Number of rows")}
-          placeholder={formatMessage("Number of rows")}
+          label="Number of rows"
+          placeholder="Number of rows"
           value={numberOfRows}
           onChange={setNumberOfRows}
         />
@@ -323,7 +323,7 @@ export const Grouped = createStory({
   columns: [
     ...exampleColumns,
     tableColumn.text({
-      headerLabel: formatMessage("Group"),
+      headerLabel: "Group",
       accessor: "group",
     }),
   ] as const,
@@ -334,15 +334,15 @@ export const Grouped = createStory({
 export const WithFillColumn = createStory({
   columns: [
     tableColumn.text({
-      headerLabel: formatMessage("Name"),
+      headerLabel: "Name",
       accessor: "name",
       width: "fill-available",
     }),
     tableColumn.textWithIcon({
-      headerLabel: formatMessage("Country"),
+      headerLabel: "Country",
       accessor: "country",
       iconPosition: "right",
-      hint: formatMessage("This is a hint"),
+      hint: "This is a hint",
     }),
   ] as const,
   data: exampleData,

--- a/packages/storybook/stories/Components/Tabs/FolderTabs.stories.tsx
+++ b/packages/storybook/stories/Components/Tabs/FolderTabs.stories.tsx
@@ -1,4 +1,4 @@
-import { createComponentStories, formatMessage } from "../../util";
+import { createComponentStories } from "../../util";
 import { IconInformative, IconNegative, FolderTabs, Chip } from "../..";
 
 const { defaultExport, createControlledStory } = createComponentStories({
@@ -13,32 +13,32 @@ export default defaultExport;
 export const medium = createControlledStory("tab1", {
   tabs: [
     {
-      label: formatMessage("Tab 1"),
+      label: "Tab 1",
       value: "tab1",
       icon: IconNegative,
       hasNotification: true,
     },
     {
-      label: formatMessage("Tab 2"),
+      label: "Tab 2",
       value: "tab2",
     },
     {
-      label: formatMessage("Tab 3"),
+      label: "Tab 3",
       value: "tab3",
       disabled: true,
     },
     {
-      label: formatMessage("Tab 4"),
+      label: "Tab 4",
       value: "tab4",
       icon: IconInformative,
       hasNotification: true,
-      rightAccessory: <Chip color="blue" label={formatMessage("A")} />,
+      rightAccessory: <Chip color="blue" label="A" />,
     },
     {
-      label: formatMessage("Tab 5"),
+      label: "Tab 5",
       value: "tab5",
       icon: IconInformative,
-      rightAccessory: <Chip color="blue" label={formatMessage("A")} />,
+      rightAccessory: <Chip color="blue" label="A" />,
     },
   ],
 });
@@ -47,22 +47,22 @@ export const large = createControlledStory("tab1", {
   size: "large",
   tabs: [
     {
-      label: formatMessage("Tab 1"),
+      label: "Tab 1",
       value: "tab1",
       icon: IconNegative,
       hasNotification: true,
     },
     {
-      label: formatMessage("Tab 2"),
+      label: "Tab 2",
       value: "tab2",
     },
     {
-      label: formatMessage("Tab 3"),
+      label: "Tab 3",
       value: "tab3",
       disabled: true,
     },
     {
-      label: formatMessage("Tab 4"),
+      label: "Tab 4",
       value: "tab4",
       icon: IconInformative,
       hasNotification: true,
@@ -76,38 +76,38 @@ export const scrollable = createControlledStory(
     size: "large",
     tabs: [
       {
-        label: formatMessage("Tab 1"),
+        label: "Tab 1",
         value: "tab1",
         icon: IconNegative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 2"),
+        label: "Tab 2",
         value: "tab2",
         icon: IconNegative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 3"),
+        label: "Tab 3",
         value: "tab3",
         disabled: true,
         icon: IconNegative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 4"),
+        label: "Tab 4",
         value: "tab4",
         icon: IconNegative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 5"),
+        label: "Tab 5",
         value: "tab5",
         icon: IconInformative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 6"),
+        label: "Tab 6",
         value: "tab6",
         icon: IconInformative,
         hasNotification: true,

--- a/packages/storybook/stories/Components/Tabs/UnderlineTabs.stories.tsx
+++ b/packages/storybook/stories/Components/Tabs/UnderlineTabs.stories.tsx
@@ -1,4 +1,4 @@
-import { createComponentStories, formatMessage } from "../../util";
+import { createComponentStories } from "../../util";
 import { IconInformative, IconNegative, UnderlineTabs } from "../..";
 
 const { defaultExport, createControlledStory } = createComponentStories({
@@ -13,22 +13,22 @@ export default defaultExport;
 export const medium = createControlledStory("tab1", {
   tabs: [
     {
-      label: formatMessage("Tab 1"),
+      label: "Tab 1",
       value: "tab1",
       icon: IconNegative,
       hasNotification: true,
     },
     {
-      label: formatMessage("Tab 2"),
+      label: "Tab 2",
       value: "tab2",
     },
     {
-      label: formatMessage("Tab 3"),
+      label: "Tab 3",
       value: "tab3",
       disabled: true,
     },
     {
-      label: formatMessage("Tab 4"),
+      label: "Tab 4",
       value: "tab4",
       icon: IconInformative,
       hasNotification: true,
@@ -40,22 +40,22 @@ export const large = createControlledStory("tab1", {
   size: "large",
   tabs: [
     {
-      label: formatMessage("Tab 1"),
+      label: "Tab 1",
       value: "tab1",
       icon: IconNegative,
       hasNotification: true,
     },
     {
-      label: formatMessage("Tab 2"),
+      label: "Tab 2",
       value: "tab2",
     },
     {
-      label: formatMessage("Tab 3"),
+      label: "Tab 3",
       value: "tab3",
       disabled: true,
     },
     {
-      label: formatMessage("Tab 4"),
+      label: "Tab 4",
       value: "tab4",
       icon: IconInformative,
       hasNotification: true,
@@ -69,38 +69,38 @@ export const scrollable = createControlledStory(
     size: "large",
     tabs: [
       {
-        label: formatMessage("Tab 1"),
+        label: "Tab 1",
         value: "tab1",
         icon: IconNegative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 2"),
+        label: "Tab 2",
         value: "tab2",
         icon: IconNegative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 3"),
+        label: "Tab 3",
         value: "tab3",
         disabled: true,
         icon: IconNegative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 4"),
+        label: "Tab 4",
         value: "tab4",
         icon: IconNegative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 5"),
+        label: "Tab 5",
         value: "tab5",
         icon: IconInformative,
         hasNotification: true,
       },
       {
-        label: formatMessage("Tab 6"),
+        label: "Tab 6",
         value: "tab6",
         icon: IconInformative,
         hasNotification: true,

--- a/packages/storybook/stories/Components/TextArea.stories.tsx
+++ b/packages/storybook/stories/Components/TextArea.stories.tsx
@@ -1,13 +1,13 @@
 import { TextArea } from "..";
-import { createComponentStories, fieldArgTypes, formatMessage, textArgType } from "../util";
+import { createComponentStories, fieldArgTypes, textArgType } from "../util";
 
 const { defaultExport, createStory, createControlledStory } = createComponentStories({
   component: TextArea,
   args: {
     name: "description",
-    label: formatMessage("Description"),
-    placeholder: formatMessage("Insert description"),
-    assistiveText: formatMessage("Add a description"),
+    label: "Description",
+    placeholder: "Insert description",
+    assistiveText: "Add a description",
   },
   argTypes: {
     ...fieldArgTypes,
@@ -24,7 +24,7 @@ export const Disabled = createControlledStory("", {
 });
 
 export const Error = createControlledStory("", {
-  issues: [formatMessage("Please insert at least 3 words")],
+  issues: ["Please insert at least 3 words"],
 });
 
 export const ReadOnly = createStory({

--- a/packages/storybook/stories/Components/TextField.stories.tsx
+++ b/packages/storybook/stories/Components/TextField.stories.tsx
@@ -1,15 +1,13 @@
 import { TextField } from "..";
-import { createComponentStories, fieldArgTypes, formatMessage, textArgType } from "../util";
+import { createComponentStories, fieldArgTypes, textArgType } from "../util";
 
 const { defaultExport, createStory, createControlledStory } = createComponentStories({
   component: TextField,
   args: {
     name: "nickname",
-    label: formatMessage("Nickname"),
-    placeholder: formatMessage("Insert your nickname"),
-    assistiveText: formatMessage(
-      "Your nickname is the name people commonly use to informally refer to you"
-    ),
+    label: "Nickname",
+    placeholder: "Insert your nickname",
+    assistiveText: "Your nickname is the name people commonly use to informally refer to you",
   },
   argTypes: {
     ...fieldArgTypes,
@@ -26,7 +24,7 @@ export const Disabled = createControlledStory("", {
 });
 
 export const Error = createControlledStory("", {
-  issues: [formatMessage("Please insert at least 3 characters")],
+  issues: ["Please insert at least 3 characters"],
 });
 
 export const ReadOnly = createStory({

--- a/packages/storybook/stories/Components/Toast.stories.tsx
+++ b/packages/storybook/stories/Components/Toast.stories.tsx
@@ -1,5 +1,5 @@
-import { DesignSystemProvider, Toast, useToast } from "..";
-import { createComponentStories, formatMessage, textArgType } from "../util";
+import { BentoProvider, Toast, useToast } from "..";
+import { createComponentStories, textArgType } from "../util";
 import { action } from "@storybook/addon-actions";
 import { ComponentProps, useEffect } from "react";
 import { Meta, StoryFn } from "@storybook/react";
@@ -8,7 +8,7 @@ import { defaultMessages } from "../defaultMessages";
 const { defaultExport, createStory } = createComponentStories({
   component: Toast,
   args: {
-    message: formatMessage("This is a message for you"),
+    message: "This is a message for you",
   },
   argTypes: {
     message: textArgType,
@@ -31,7 +31,7 @@ export const NonDismissable = createStory(
 export const MessageAndAction = createStory({
   kind: "informative",
   action: {
-    label: formatMessage("Action"),
+    label: "Action",
     onPress: action("onPress"),
   },
 });
@@ -40,7 +40,7 @@ export const NonDismissableAndAction = createStory(
   {
     kind: "informative",
     action: {
-      label: formatMessage("Action"),
+      label: "Action",
       onPress: action("onPress"),
     },
   },
@@ -50,7 +50,7 @@ export const NonDismissableAndAction = createStory(
 export const Positive = createStory({
   kind: "positive",
   action: {
-    label: formatMessage("Action"),
+    label: "Action",
     onPress: action("onPress"),
   },
 });
@@ -58,7 +58,7 @@ export const Positive = createStory({
 export const Negative = createStory({
   kind: "negative",
   action: {
-    label: formatMessage("Action"),
+    label: "Action",
     onPress: action("onPress"),
   },
 });
@@ -66,7 +66,7 @@ export const Negative = createStory({
 export const Warning = createStory({
   kind: "warning",
   action: {
-    label: formatMessage("Action"),
+    label: "Action",
     onPress: action("onPress"),
   },
 });
@@ -74,7 +74,7 @@ export const Warning = createStory({
 export const Secondary = createStory({
   kind: "secondary",
   action: {
-    label: formatMessage("Action"),
+    label: "Action",
     onPress: action("onPress"),
   },
 });
@@ -88,7 +88,7 @@ export const WithProvider = ({
     showToast({
       message,
       kind,
-      action: { label: formatMessage("Action"), onPress: action("onPress") },
+      action: { label: "Action", onPress: action("onPress") },
       dismissable: true,
     });
   }, [message, kind, showToast]);
@@ -98,8 +98,8 @@ export const WithProvider = ({
 
 WithProvider.decorators = [
   (StoryFn: StoryFn) => (
-    <DesignSystemProvider toastDismissAfterMs={1000000} defaultMessages={defaultMessages}>
+    <BentoProvider toastDismissAfterMs={1000000} defaultMessages={defaultMessages}>
       <StoryFn />
-    </DesignSystemProvider>
+    </BentoProvider>
   ),
 ];

--- a/packages/storybook/stories/Components/Tooltip.stories.tsx
+++ b/packages/storybook/stories/Components/Tooltip.stories.tsx
@@ -1,10 +1,10 @@
-import { Box, IconWarning, Tooltip, TooltipProps } from "../";
-import { createComponentStories, formatMessage } from "../util";
+import { Box, IconWarning, Tooltip, TooltipProps } from "..";
+import { createComponentStories } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Tooltip,
   args: {
-    content: formatMessage("Tooltip content"),
+    content: "Tooltip content",
   },
 });
 

--- a/packages/storybook/stories/Foundations/Box.stories.tsx
+++ b/packages/storybook/stories/Foundations/Box.stories.tsx
@@ -1,10 +1,10 @@
 import { Box } from "..";
-import { createComponentStories, formatMessage } from "../util";
+import { createComponentStories } from "../util";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Box,
   args: {
-    children: formatMessage("Test"),
+    children: "Test",
   },
 });
 

--- a/packages/storybook/stories/Foundations/Icons.stories.tsx
+++ b/packages/storybook/stories/Foundations/Icons.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta } from "@storybook/react";
 import { Box, Inline, Stack, Body, IconProps, icons } from "..";
-import { formatMessage } from "../util";
 
 const meta = {
   args: {
@@ -30,7 +29,7 @@ export const Icons = (args: IconProps) => {
               <Box display="flex" alignItems="center" style={{ height: 24 }}>
                 <Icon size={args.size} color={args.color} />
               </Box>
-              <Body size="small">{formatMessage(name.replace(/^Icon/g, ""))}</Body>
+              <Body size="small">{name.replace(/^Icon/g, "")}</Body>
             </Stack>
           </Box>
         ))}

--- a/packages/storybook/stories/Foundations/Illustrations.stories.tsx
+++ b/packages/storybook/stories/Foundations/Illustrations.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta } from "@storybook/react";
 import { Box, Inline, Stack, Body, IllustrationProps, illustrations } from "..";
-import { formatMessage } from "../util";
 
 const meta = {
   args: {
@@ -47,7 +46,7 @@ export const Illustrations = (args: IllustrationProps) => {
               <Box display="flex" alignItems="center" style={{ height: 24 }}>
                 <Illustration {...illustrationProps} />
               </Box>
-              <Body size="small">{formatMessage(name.replace(/^Icon/g, ""))}</Body>
+              <Body size="small">{name.replace(/^Icon/g, "")}</Body>
             </Stack>
           </Box>
         ))}

--- a/packages/storybook/stories/Foundations/Typography/Body.stories.tsx
+++ b/packages/storybook/stories/Foundations/Typography/Body.stories.tsx
@@ -1,10 +1,10 @@
-import { createComponentStories, formatMessage, textArgType } from "../../util";
+import { createComponentStories, textArgType } from "../../util";
 import { Body } from "../..";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Body,
   args: {
-    children: formatMessage("The quick brown fox jumps over the lazy dog"),
+    children: "The quick brown fox jumps over the lazy dog",
   },
   argTypes: {
     children: textArgType,

--- a/packages/storybook/stories/Foundations/Typography/Display.stories.tsx
+++ b/packages/storybook/stories/Foundations/Typography/Display.stories.tsx
@@ -1,10 +1,10 @@
-import { createComponentStories, formatMessage, textArgType } from "../../util";
+import { createComponentStories, textArgType } from "../../util";
 import { Display } from "../..";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Display,
   args: {
-    children: formatMessage("The quick brown fox"),
+    children: "The quick brown fox",
   },
   argTypes: {
     children: textArgType,

--- a/packages/storybook/stories/Foundations/Typography/Headline.stories.tsx
+++ b/packages/storybook/stories/Foundations/Typography/Headline.stories.tsx
@@ -1,10 +1,10 @@
-import { createComponentStories, formatMessage, textArgType } from "../../util";
+import { createComponentStories, textArgType } from "../../util";
 import { Headline } from "../..";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Headline,
   args: {
-    children: formatMessage("The quick brown fox"),
+    children: "The quick brown fox",
   },
   argTypes: {
     children: textArgType,

--- a/packages/storybook/stories/Foundations/Typography/Label.stories.tsx
+++ b/packages/storybook/stories/Foundations/Typography/Label.stories.tsx
@@ -1,10 +1,10 @@
-import { createComponentStories, formatMessage, textArgType } from "../../util";
+import { createComponentStories, textArgType } from "../../util";
 import { Label } from "../..";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Label,
   args: {
-    children: formatMessage("The quick brown fox"),
+    children: "The quick brown fox",
   },
   argTypes: {
     children: textArgType,

--- a/packages/storybook/stories/Foundations/Typography/Title.stories.tsx
+++ b/packages/storybook/stories/Foundations/Typography/Title.stories.tsx
@@ -1,10 +1,10 @@
-import { createComponentStories, formatMessage, textArgType } from "../../util";
+import { createComponentStories, textArgType } from "../../util";
 import { Title } from "../..";
 
 const { defaultExport, createStory } = createComponentStories({
   component: Title,
   args: {
-    children: formatMessage("The quick brown fox"),
+    children: "The quick brown fox",
   },
   argTypes: {
     children: textArgType,

--- a/packages/storybook/stories/defaultMessages.ts
+++ b/packages/storybook/stories/defaultMessages.ts
@@ -1,45 +1,42 @@
 import { ComponentProps } from "react";
 import { BentoProvider } from ".";
-import { formatMessage } from "./util";
 
 export const defaultMessages: ComponentProps<typeof BentoProvider>["defaultMessages"] = {
   Chip: {
-    dismissButtonLabel: formatMessage("Remove"),
+    dismissButtonLabel: "Remove",
   },
   Banner: {
-    dismissButtonLabel: formatMessage("Close"),
+    dismissButtonLabel: "Close",
   },
   Modal: {
-    closeButtonLabel: formatMessage("Close"),
+    closeButtonLabel: "Close",
   },
   SelectField: {
-    noOptionsMessage: formatMessage("No options"),
+    noOptionsMessage: "No options",
     multiOptionsSelected: (n) => {
       const options = n > 1 ? "options" : "option";
-      return formatMessage(`${n} ${options} selected`);
+      return `${n} ${options} selected`;
     },
-    selectAllButtonLabel: formatMessage("Select all"),
-    clearAllButtonLabel: formatMessage("Clear all"),
+    selectAllButtonLabel: "Select all",
+    clearAllButtonLabel: "Clear all",
   },
   SearchBar: {
-    clearButtonLabel: formatMessage("Clear"),
+    clearButtonLabel: "Clear",
   },
   Table: {
-    noResultsTitle: formatMessage("No results found"),
-    noResultsDescription: formatMessage(
-      "Try adjusting your search filters to find what you're looking for."
-    ),
-    missingValue: formatMessage("-"),
+    noResultsTitle: "No results found",
+    noResultsDescription: "Try adjusting your search filters to find what you're looking for.",
+    missingValue: "-",
   },
   Loader: {
-    loadingMessage: formatMessage("Loading..."),
+    loadingMessage: "Loading...",
   },
   DateField: {
-    previousMonthLabel: formatMessage("Prev month"),
-    nextMonthLabel: formatMessage("Next month"),
+    previousMonthLabel: "Prev month",
+    nextMonthLabel: "Next month",
   },
   TextField: {
-    showPasswordLabel: formatMessage("Show password"),
-    hidePasswordLabel: formatMessage("Hide password"),
+    showPasswordLabel: "Show password",
+    hidePasswordLabel: "Hide password",
   },
 };

--- a/packages/storybook/stories/index.tsx
+++ b/packages/storybook/stories/index.tsx
@@ -58,7 +58,6 @@ export {
   CustomModal,
   DateField,
   DecorativeDivider,
-  DesignSystemProvider,
   Disclosure,
   DisclosureGroup,
   Display,

--- a/packages/storybook/stories/index.tsx
+++ b/packages/storybook/stories/index.tsx
@@ -72,6 +72,7 @@ export {
   InlineLoader,
   Inset,
   Label,
+  Link,
   List,
   ListItem,
   Menu,
@@ -122,13 +123,17 @@ export {
   useToast,
   svgIllustrationProps,
   svgIconProps,
+  illustrations,
+  icons,
 } from "@buildo/bento-design-system";
 
 export type {
+  IconProps,
+  IllustrationProps,
   Omit,
+  SelectFieldProps,
   SliderFieldProps,
   TooltipProps,
-  IllustrationProps,
 } from "@buildo/bento-design-system";
 
 export const BentoProvider = createBentoProvider(

--- a/packages/storybook/stories/index.tsx
+++ b/packages/storybook/stories/index.tsx
@@ -2,13 +2,14 @@ import "@buildo/bento-design-system/lib/index.css";
 import "@buildo/bento-design-system/lib/defaultTheme.css";
 import "./theme.css";
 import {
-  createBentoComponents,
+  createBentoProvider,
   defaultConfigs,
   withBentoConfig,
+  Actions,
+  Tabs,
 } from "@buildo/bento-design-system";
 import { sprinkles } from "./sprinkles.css";
 
-export * from "@buildo/bento-design-system";
 const FeedbackBackground = (
   <svg viewBox="0 0 440 240">
     <path
@@ -35,7 +36,7 @@ const FeedbackBackground = (
   </svg>
 );
 
-export const {
+export {
   Actions,
   AreaLoader,
   Avatar,
@@ -56,7 +57,6 @@ export const {
   ContentWithSidebar,
   CustomModal,
   DateField,
-  DesignSystemProvider,
   DecorativeDivider,
   Disclosure,
   DisclosureGroup,
@@ -119,16 +119,31 @@ export const {
   IllustrationNegative,
   IllustrationSearch,
   useComponentsShowcase,
-} = createBentoComponents(sprinkles, {
-  chip: {
-    customColors: {
-      custom: "customColor1",
+  useToast,
+  svgIllustrationProps,
+  svgIconProps,
+} from "@buildo/bento-design-system";
+
+export type {
+  Omit,
+  SliderFieldProps,
+  TooltipProps,
+  IllustrationProps,
+} from "@buildo/bento-design-system";
+
+export const BentoProvider = createBentoProvider(
+  {
+    chip: {
+      customColors: {
+        custom: "customColor1",
+      },
+    },
+    feedback: {
+      background: FeedbackBackground,
     },
   },
-  feedback: {
-    background: FeedbackBackground,
-  },
-});
+  sprinkles
+);
 
 export const FolderTabs = Tabs;
 export const UnderlineTabs = withBentoConfig({ tabs: defaultConfigs.underlineTabs }, Tabs);

--- a/packages/storybook/stories/index.tsx
+++ b/packages/storybook/stories/index.tsx
@@ -58,6 +58,7 @@ export {
   CustomModal,
   DateField,
   DecorativeDivider,
+  DesignSystemProvider,
   Disclosure,
   DisclosureGroup,
   Display,

--- a/packages/storybook/stories/index.tsx
+++ b/packages/storybook/stories/index.tsx
@@ -5,8 +5,7 @@ import {
   createBentoProvider,
   defaultConfigs,
   withBentoConfig,
-  Actions,
-  Tabs,
+  createBentoComponents,
 } from "@buildo/bento-design-system";
 import { sprinkles } from "./sprinkles.css";
 
@@ -36,7 +35,22 @@ const FeedbackBackground = (
   </svg>
 );
 
-export {
+// NOTE(gabro): we're still using createBentoComponents instead of exporting the
+// components directly from @buildo/bento-design-system due to
+// https://github.com/storybookjs/storybook/issues/12185
+// In short, Storybook (which uses react-docgen-typescript) does not pick up the
+// props when the component comes from an external library.
+//
+// The workaround would be to wrap each component in another component that just
+// re-exports it (see https://github.com/storybookjs/storybook/issues/13502#issuecomment-752897475),
+// but that would be way too inconvenient.
+//
+// Using createBentoComponents creates the components directly in Storybook, so
+// their props are picked up correctly.
+//
+// We tried several solutions from the linked issues, but it seems our monorepo
+// setup make this particularly tricky
+export const {
   Actions,
   AreaLoader,
   Avatar,
@@ -120,6 +134,9 @@ export {
   IllustrationNegative,
   IllustrationSearch,
   useComponentsShowcase,
+} = createBentoComponents();
+
+export {
   useToast,
   svgIllustrationProps,
   svgIconProps,

--- a/packages/storybook/stories/index.tsx
+++ b/packages/storybook/stories/index.tsx
@@ -142,6 +142,7 @@ export {
   svgIconProps,
   illustrations,
   icons,
+  BentoConfigProvider,
 } from "@buildo/bento-design-system";
 
 export type {

--- a/packages/storybook/stories/util.tsx
+++ b/packages/storybook/stories/util.tsx
@@ -2,7 +2,6 @@ import { Parameters } from "@storybook/addons";
 import { ComponentStory } from "@storybook/react";
 import { JSXElementConstructor, ComponentProps, useState } from "react";
 import {
-  unsafeLocalizedString,
   Omit,
   alignToFlexAlignLookup,
   alignYToFlexAlignLookup,
@@ -103,5 +102,3 @@ export const fieldArgTypes = {
   issues: issuesArgType,
   hint: textArgType,
 };
-
-export const formatMessage = unsafeLocalizedString;

--- a/packages/storybook/stories/util.tsx
+++ b/packages/storybook/stories/util.tsx
@@ -1,8 +1,13 @@
 import { Parameters } from "@storybook/addons";
 import { ComponentStory } from "@storybook/react";
 import { JSXElementConstructor, ComponentProps, useState } from "react";
-import { unsafeLocalizedString, Omit, alignToFlexAlignLookup, alignYToFlexAlignLookup } from ".";
-import { vars } from "@buildo/bento-design-system";
+import {
+  unsafeLocalizedString,
+  Omit,
+  alignToFlexAlignLookup,
+  alignYToFlexAlignLookup,
+  vars,
+} from "@buildo/bento-design-system";
 
 export type Actions<Props> = {
   [k in keyof Props]-?: k extends `on${infer _}` ? k : never;


### PR DESCRIPTION
~Migrate the storybook to the recently introduced API (no more `createBentoComponents`).~

As a bonus, I've also removed all uses of `formatMessage` since it became useless after #165.