### PR TITLE
Remove duplicate FieldProps eport

### DIFF
--- a/packages/bento-design-system/src/Field/Field.tsx
+++ b/packages/bento-design-system/src/Field/Field.tsx
@@ -108,4 +108,3 @@ export function Field({
 }
 
 export type FieldType = React.FunctionComponent<Props>;
-export type { Props as FieldProps };


### PR DESCRIPTION
We accidentally exported also the props of `Field` as `FieldProps`, which would then shadow the original `FieldProps`.

I've opted for removing the export since it doesn't feel very useful and it can be always retrieved as `ComponentProps<typeof Field>` if needed