### PR TITLE
#381: Certain navigation components don't trigger their action

### DIFF
--- a/packages/bento-design-system/src/Box/Box.tsx
+++ b/packages/bento-design-system/src/Box/Box.tsx
@@ -36,7 +36,7 @@ export const Box: BoxType = forwardRef<HTMLElement, Props>(
     const sprinkles = useSprinkles();
     const { atomProps, customProps, otherProps } = extractAtomsFromProps(props, sprinkles);
 
-    const el = typeof element === "string" ? element : "div";
+    const el = element ?? "div";
     const elementReset = resetStyles.element[el as keyof typeof resetStyles.element];
 
     return createElement(el, {


### PR DESCRIPTION
Closes #381

Components acting as `LinkComponent` were not working correctly, because they were not handled properly in `Box`.
That was happening because of this check:
```typescript
    const el = typeof element === "string" ? element : "div";
```
which, before the refactor, was only used to determine which `resetStyle` was to be applied to the element. After the refactor, this check also determined what element was created. When `as={LinkComponent}` was passed to `Box`, this check would return `div` and therefore it wouldn't behave as a link.

## Test Plan
✅ Components depending on `LinkComponent` work correctly