### PR TITLE
Fix bug when nesting BentoConfigProvider

### DIFF
--- a/packages/bento-design-system/src/BentoConfigContext.tsx
+++ b/packages/bento-design-system/src/BentoConfigContext.tsx
@@ -17,8 +17,13 @@ export function BentoConfigProvider({
   value: PartialBentoConfig;
   children: Children;
 }) {
+  // NOTE(gabro): in case we nest config providers, each nested provider should only override the
+  // partial config it was given.
+  // So we retrieve the parent config via useBentoConfig(), which will default to the default config
+  // in case this is the top level provider.
+  const parentConfig = useBentoConfig();
   return (
-    <BentoConfigContext.Provider value={merge(defaultConfigs, config)}>
+    <BentoConfigContext.Provider value={merge(parentConfig, config)}>
       {children}
     </BentoConfigContext.Provider>
   );

--- a/packages/storybook/stories/Utils/withBentoConfig.stories.tsx
+++ b/packages/storybook/stories/Utils/withBentoConfig.stories.tsx
@@ -1,0 +1,49 @@
+import {
+  DesignSystemProvider,
+  Modal as BentoModal,
+  withBentoConfig,
+} from "@buildo/bento-design-system";
+import { action } from "@storybook/addon-actions";
+import { defaultMessages } from "../defaultMessages";
+
+export default {};
+
+// This tests that `withBentoConfig` only overrides the specific config passed to it.
+// In this case we check that when we customize the Modal, we don't change the
+// Button configuration that was provided by the top-level DesignSystemProvider.
+//
+// In practice, we should see a custom Modal with its radius and padding overridden,
+// and also a custom Button with its radius overridden by the top-level config.
+export const ConfiguredModal = () => {
+  const Modal = withBentoConfig(
+    {
+      modal: {
+        radius: 16,
+        paddingX: 80,
+      },
+    },
+    BentoModal
+  );
+
+  return (
+    <DesignSystemProvider
+      defaultMessages={defaultMessages}
+      config={{
+        button: {
+          radius: 16,
+        },
+      }}
+    >
+      <Modal
+        title="Custom Modal"
+        onClose={action("onClose")}
+        primaryAction={{
+          label: "Primary action",
+          onPress: action("onPrimaryActionPress"),
+        }}
+      >
+        Modal content
+      </Modal>
+    </DesignSystemProvider>
+  );
+};


### PR DESCRIPTION
Previously we would merge the partial config given to each provider with `defaultConfig`, which would effectively "reset" every other config in the descendent component tree.

Now we instead merge each provider's partial config with their parent config, which is `defaultConfig` for the top-level one.