### PR TITLE
Make SelectField use its own List config

### DIFF
--- a/packages/bento-design-system/src/SelectField/SelectField.tsx
+++ b/packages/bento-design-system/src/SelectField/SelectField.tsx
@@ -13,7 +13,7 @@ import * as selectComponents from "./components";
 import { ListItemProps } from "../List/ListItem";
 import { Omit } from "../util/Omit";
 import { useDefaultMessages } from "../util/useDefaultMessages";
-import { useBentoConfig } from "../BentoConfigContext";
+import { BentoConfigProvider, useBentoConfig } from "../BentoConfigContext";
 
 export type SelectOption<A> = Omit<
   ListItemProps,
@@ -97,96 +97,99 @@ export function SelectField<A, IsMulti extends boolean = false>(props: Props<A, 
   const { defaultMessages } = useDefaultMessages();
 
   return (
-    <Field
-      label={label}
-      hint={hint}
-      labelProps={labelProps}
-      assistiveText={assistiveText}
-      issues={issues}
-      assistiveTextProps={descriptionProps}
-      errorMessageProps={errorMessageProps}
-      disabled={disabled}
-    >
-      <Select
-        id={fieldProps.id}
-        aria-label={fieldProps["aria-label"]}
-        aria-labelledby={fieldProps["aria-labelledby"]}
-        isDisabled={disabled}
-        isReadOnly={isReadOnly || false}
-        autoFocus={autoFocus}
-        value={
-          isMulti
-            ? options.filter((o) => ((value ?? []) as readonly A[]).includes(o.value))
-            : options.find((o) => o.value === value)
-        }
-        onChange={(o) => {
-          if (isMulti) {
-            const multiValue = o as MultiValueT<SelectOption<A>>;
-            (onChange as Props<A, true>["onChange"])(multiValue.map((a) => a.value));
-          } else {
-            const singleValue = o as SingleValueT<SelectOption<A>>;
-            (onChange as Props<A, false>["onChange"])(
-              singleValue == null ? undefined : singleValue.value
-            );
+    // NOTE(gabro): SelectField has its own config for List, so we override it here using BentoConfigProvider
+    <BentoConfigProvider value={{ list: dropdownConfig.list }}>
+      <Field
+        label={label}
+        hint={hint}
+        labelProps={labelProps}
+        assistiveText={assistiveText}
+        issues={issues}
+        assistiveTextProps={descriptionProps}
+        errorMessageProps={errorMessageProps}
+        disabled={disabled}
+      >
+        <Select
+          id={fieldProps.id}
+          aria-label={fieldProps["aria-label"]}
+          aria-labelledby={fieldProps["aria-labelledby"]}
+          isDisabled={disabled}
+          isReadOnly={isReadOnly || false}
+          autoFocus={autoFocus}
+          value={
+            isMulti
+              ? options.filter((o) => ((value ?? []) as readonly A[]).includes(o.value))
+              : options.find((o) => o.value === value)
           }
-        }}
-        onBlur={onBlur}
-        options={options
-          .slice() // avoid mutating the original array
-          .sort((a, b) => {
-            // In case of multi-select, we display the selected options first
+          onChange={(o) => {
             if (isMulti) {
-              const selectedValues = (value ?? []) as readonly A[];
-              const isSelected = (a: SelectOption<A>) => selectedValues.includes(a.value);
-              if (isSelected(a) && !isSelected(b)) {
-                return -1;
-              }
-              if (!isSelected(a) && isSelected(b)) {
-                return 1;
-              }
+              const multiValue = o as MultiValueT<SelectOption<A>>;
+              (onChange as Props<A, true>["onChange"])(multiValue.map((a) => a.value));
+            } else {
+              const singleValue = o as SingleValueT<SelectOption<A>>;
+              (onChange as Props<A, false>["onChange"])(
+                singleValue == null ? undefined : singleValue.value
+              );
             }
-            return 0;
-          })}
-        placeholder={placeholder}
-        menuPortalTarget={menuPortalTarget}
-        components={{
-          ...selectComponents,
-          MultiValue,
-        }}
-        openMenuOnFocus
-        styles={selectComponents.styles<SelectOption<A>, IsMulti>()}
-        validationState={validationState}
-        isMulti={isMulti}
-        isClearable={false}
-        noOptionsMessage={() => noOptionsMessage ?? defaultMessages.SelectField.noOptionsMessage}
-        multiValueMessage={
-          isMulti
-            ? (props as unknown as Props<A, true>).multiValueMessage ??
-              defaultMessages.SelectField.multiOptionsSelected
-            : undefined
-        }
-        closeMenuOnSelect={!isMulti}
-        hideSelectedOptions={false}
-        menuSize={menuSize}
-        menuIsOpen={isReadOnly ? false : undefined}
-        isSearchable={isReadOnly ? false : searchable ?? true}
-        showMultiSelectBulkActions={
-          isMulti ? (props as unknown as Props<A, true>).showMultiSelectBulkActions : false
-        }
-        clearAllButtonLabel={
-          isMulti
-            ? (props as unknown as Props<A, true>).clearAllButtonLabel ??
-              defaultMessages.SelectField.clearAllButtonLabel
-            : undefined
-        }
-        selectAllButtonLabel={
-          isMulti
-            ? (props as unknown as Props<A, true>).selectAllButtonLabel ??
-              defaultMessages.SelectField.selectAllButtonLabel
-            : undefined
-        }
-      />
-    </Field>
+          }}
+          onBlur={onBlur}
+          options={options
+            .slice() // avoid mutating the original array
+            .sort((a, b) => {
+              // In case of multi-select, we display the selected options first
+              if (isMulti) {
+                const selectedValues = (value ?? []) as readonly A[];
+                const isSelected = (a: SelectOption<A>) => selectedValues.includes(a.value);
+                if (isSelected(a) && !isSelected(b)) {
+                  return -1;
+                }
+                if (!isSelected(a) && isSelected(b)) {
+                  return 1;
+                }
+              }
+              return 0;
+            })}
+          placeholder={placeholder}
+          menuPortalTarget={menuPortalTarget}
+          components={{
+            ...selectComponents,
+            MultiValue,
+          }}
+          openMenuOnFocus
+          styles={selectComponents.styles<SelectOption<A>, IsMulti>()}
+          validationState={validationState}
+          isMulti={isMulti}
+          isClearable={false}
+          noOptionsMessage={() => noOptionsMessage ?? defaultMessages.SelectField.noOptionsMessage}
+          multiValueMessage={
+            isMulti
+              ? (props as unknown as Props<A, true>).multiValueMessage ??
+                defaultMessages.SelectField.multiOptionsSelected
+              : undefined
+          }
+          closeMenuOnSelect={!isMulti}
+          hideSelectedOptions={false}
+          menuSize={menuSize}
+          menuIsOpen={isReadOnly ? false : undefined}
+          isSearchable={isReadOnly ? false : searchable ?? true}
+          showMultiSelectBulkActions={
+            isMulti ? (props as unknown as Props<A, true>).showMultiSelectBulkActions : false
+          }
+          clearAllButtonLabel={
+            isMulti
+              ? (props as unknown as Props<A, true>).clearAllButtonLabel ??
+                defaultMessages.SelectField.clearAllButtonLabel
+              : undefined
+          }
+          selectAllButtonLabel={
+            isMulti
+              ? (props as unknown as Props<A, true>).selectAllButtonLabel ??
+                defaultMessages.SelectField.selectAllButtonLabel
+              : undefined
+          }
+        />
+      </Field>
+    </BentoConfigProvider>
   );
 }
 

--- a/packages/bento-design-system/src/index.ts
+++ b/packages/bento-design-system/src/index.ts
@@ -107,6 +107,7 @@ export * from "./vars.css";
 
 export type { BentoConfig, PartialBentoConfig } from "./BentoConfig";
 export { defaultConfigs };
+export { BentoConfigProvider } from "./BentoConfigContext";
 
 export { createBentoComponents } from "./createBentoComponents";
 

--- a/packages/storybook/stories/Components/SelectField.stories.tsx
+++ b/packages/storybook/stories/Components/SelectField.stories.tsx
@@ -6,6 +6,7 @@ import {
   Modal,
   SelectField,
   svgIllustrationProps,
+  BentoConfigProvider,
 } from "../";
 import { createComponentStories, fieldArgTypes, formatMessage, textArgType } from "../util";
 
@@ -120,3 +121,25 @@ export const ReadOnly = createStory({
   ],
   isReadOnly: true,
 });
+
+// This story tests that we can configure List specifically for SelectField
+export const CustomListConfig = createStory({
+  autoFocus: true,
+});
+CustomListConfig.decorators = [
+  (Story: StoryFn) => (
+    <BentoConfigProvider
+      value={{
+        dropdown: {
+          list: {
+            item: {
+              paddingX: { large: 80, medium: 80 },
+            },
+          },
+        },
+      }}
+    >
+      <Story />
+    </BentoConfigProvider>
+  ),
+];

--- a/packages/storybook/stories/Components/SelectField.stories.tsx
+++ b/packages/storybook/stories/Components/SelectField.stories.tsx
@@ -139,7 +139,9 @@ CustomListConfig.decorators = [
         },
       }}
     >
-      <Story />
+      <Modal title="Title" onClose={() => {}}>
+        <Story />
+      </Modal>
     </BentoConfigProvider>
   ),
 ];


### PR DESCRIPTION
Due to the refactor introduced in #358 dropdown config (used by `SelectField`) was not overriding its own `List` anymore.

This PR fixes it and adds a new story to stress that use case.