### PR TITLE
Fix playroom deploy

### DIFF
--- a/packages/bento-design-system/playroom/FrameComponent.tsx
+++ b/packages/bento-design-system/playroom/FrameComponent.tsx
@@ -1,12 +1,12 @@
-import { Box, DesignSystemProvider } from "../../storybook/stories";
+import { Box, BentoProvider } from "../../storybook/stories";
 import { defaultMessages } from "../../storybook/stories/defaultMessages";
 
 export default function FrameComponent({ theme, children }) {
   return (
-    <DesignSystemProvider defaultMessages={defaultMessages}>
+    <BentoProvider defaultMessages={defaultMessages}>
       <Box className={theme} background="backgroundPrimary">
         {children}
       </Box>
-    </DesignSystemProvider>
+    </BentoProvider>
   );
 }


### PR DESCRIPTION
This was broken by #358 and it went unnoticed since the main playroom build wasn't broken, but it wouldn't work when loading the custom `FrameComponent`