### PR TITLE
#395: Bug: Custom sprinkles are overridden by the default ones in some components

### DIFF
--- a/packages/bento-design-system/src/AreaLoader/AreaLoader.tsx
+++ b/packages/bento-design-system/src/AreaLoader/AreaLoader.tsx
@@ -1,10 +1,11 @@
 import clsx from "clsx";
-import { bentoSprinkles, Box, Inline, Stack, Body, LocalizedString } from "..";
+import { Box, Inline, Stack, Body, LocalizedString } from "..";
 import { container, dot, text } from "./AreaLoader.css";
 import { BentoSprinkles } from "../internal";
 import { AreaLoaderConfig } from "./Config";
 import { BodyProps } from "../Typography/Body/Body";
 import { useBentoConfig } from "../BentoConfigContext";
+import { useSprinkles } from "../SprinklesContext";
 
 function readabilityAreaColorToBackground(
   color: AreaLoaderConfig["readabilityAreaColor"]
@@ -54,18 +55,20 @@ export type { Props as AreaLoaderProps };
  */
 export function AreaLoader({ message }: Props) {
   const config = useBentoConfig().areaLoader;
+  const sprinkles = useSprinkles();
+
   return (
     <Box
       className={clsx(
         container,
-        bentoSprinkles({
+        sprinkles({
           background: config.scrimColor === "dark" ? "backgroundDarkScrim" : "backgroundLightScrim",
         })
       )}
     >
       <Box
         padding={80}
-        className={bentoSprinkles({
+        className={sprinkles({
           background: readabilityAreaColorToBackground(config.readabilityAreaColor),
           borderRadius: config.readabilityAreaBorderRadius,
         })}
@@ -75,7 +78,7 @@ export function AreaLoader({ message }: Props) {
             {config.dots.map((dotConfig, index) => (
               <Box
                 key={`dot-${index}`}
-                className={clsx(dot, bentoSprinkles({ background: dotConfig.color }))}
+                className={clsx(dot, sprinkles({ background: dotConfig.color }))}
                 style={{
                   animationDelay: `${0.2 * index}s`,
                 }}

--- a/packages/bento-design-system/src/SelectField/components.tsx
+++ b/packages/bento-design-system/src/SelectField/components.tsx
@@ -27,7 +27,6 @@ import {
   Column,
   Inline,
   Inset,
-  bentoSprinkles,
   Button,
 } from "..";
 import { singleValue, placeholder, menu, control } from "./SelectField.css";
@@ -37,6 +36,7 @@ import { SelectOption } from "./SelectField";
 import { InternalList } from "../List/InternalList";
 import { ListItem } from "../List/ListItem";
 import { useBentoConfig } from "../BentoConfigContext";
+import { useSprinkles } from "../SprinklesContext";
 
 export function Control<A, IsMulti extends boolean>({
   selectProps: { validationState: validation, isDisabled, isReadOnly = false },
@@ -65,10 +65,12 @@ export function Control<A, IsMulti extends boolean>({
 }
 
 export function ValueContainer<A, IsMulti extends boolean>(props: ValueContainerProps<A, IsMulti>) {
+  const sprinkles = useSprinkles();
+
   return (
     <defaultComponents.ValueContainer
       {...props}
-      className={bentoSprinkles({
+      className={sprinkles({
         gap: 8,
       })}
     />
@@ -144,6 +146,7 @@ export function Input<A, IsMulti extends boolean>(props: InputProps<A, IsMulti>)
 
 export function Menu<A, IsMulti extends boolean>(props: MenuProps<A, IsMulti>) {
   const dropdownConfig = useBentoConfig().dropdown;
+  const sprinkles = useSprinkles();
 
   const elevation = (() => {
     switch (dropdownConfig.elevation) {
@@ -161,7 +164,7 @@ export function Menu<A, IsMulti extends boolean>(props: MenuProps<A, IsMulti>) {
       {...props}
       className={clsx(
         menu,
-        bentoSprinkles({
+        sprinkles({
           boxShadow: elevation,
           borderRadius: dropdownConfig.radius,
         })


### PR DESCRIPTION
Closes #395

## Test Plan

### tests performed

The bug is not reproducible anymore with the dropdown component

### tests not performed

I did not test the `AreaLoader` component
