### PR TITLE
Fix the alignment of labels in `fill-parent` Tabs

### DIFF
--- a/packages/bento-design-system/src/Tabs/Tabs.tsx
+++ b/packages/bento-design-system/src/Tabs/Tabs.tsx
@@ -64,7 +64,7 @@ function Tab({
       borderBottomWidth={config.kind === "underline" ? config.lineHeight : undefined}
       borderStyle="solid"
     >
-      <Columns space={config.internalSpacing} alignY="center">
+      <Columns space={config.internalSpacing} alignY="center" align="center">
         {icon && (
           <Column width="content">{icon({ size: config.iconSize, color: "inherit" })}</Column>
         )}


### PR DESCRIPTION
Closes #422 

<img width="1525" alt="Screenshot 2022-11-08 alle 18 07 28" src="https://user-images.githubusercontent.com/34537387/200630758-e112ad52-bd20-4d1d-b032-fba71443eb34.png">
