### PR TITLE
Improve underline configuration

### DIFF
--- a/packages/bento-design-system/src/Navigation/Config.ts
+++ b/packages/bento-design-system/src/Navigation/Config.ts
@@ -20,5 +20,5 @@ export type NavigationConfig = {
 
 type ActiveVisualElementConfig = {
   lineHeight: SizeConfig<number>;
-  lineColor: BentoSprinkles["background"];
+  lineColor: BentoSprinkles["decoration"];
 };

--- a/packages/bento-design-system/src/Navigation/Navigation.tsx
+++ b/packages/bento-design-system/src/Navigation/Navigation.tsx
@@ -81,7 +81,8 @@ function Destination({
         left={0}
         bottom={0}
         width="full"
-        background={config.activeVisualElement.lineColor}
+        background="currentColor"
+        color={config.activeVisualElement.lineColor}
         style={{ height: config.activeVisualElement.lineHeight[size] }}
       />
     );

--- a/packages/bento-design-system/src/Tabs/Config.ts
+++ b/packages/bento-design-system/src/Tabs/Config.ts
@@ -23,7 +23,7 @@ type TabsKindConfig =
   | {
       kind: "underline";
       lineHeight: BentoSprinkles["borderBottomWidth"];
-      lineColor: NonNullable<BentoSprinkles["borderColor"]>;
+      lineColor: NonNullable<BentoSprinkles["decoration"]>;
     };
 
 export type TabsConfig = TabsWidthConfig &

--- a/packages/bento-design-system/src/Tabs/Config.ts
+++ b/packages/bento-design-system/src/Tabs/Config.ts
@@ -22,7 +22,7 @@ type TabsKindConfig =
     }
   | {
       kind: "underline";
-      lineHeight: BentoSprinkles["borderBottomWidth"];
+      lineHeight: SizeConfig<number>;
       lineColor: NonNullable<BentoSprinkles["decoration"]>;
     };
 

--- a/packages/bento-design-system/src/Tabs/Tabs.tsx
+++ b/packages/bento-design-system/src/Tabs/Tabs.tsx
@@ -61,7 +61,9 @@ function Tab({
             : config.lineColor
           : undefined
       }
-      borderBottomWidth={config.kind === "underline" ? config.lineHeight : undefined}
+      style={{
+        borderBottomWidth: config.kind === "underline" ? config.lineHeight[size] : undefined,
+      }}
       borderStyle="solid"
     >
       <Columns space={config.internalSpacing} alignY="center">

--- a/packages/bento-design-system/src/util/atoms.ts
+++ b/packages/bento-design-system/src/util/atoms.ts
@@ -89,6 +89,7 @@ const color = {
   ...vars.interactiveForegroundColor,
   ...vars.outlineColor,
   ...vars.dataVisualizationColor,
+  transparent: "transparent",
 };
 
 const background = {
@@ -99,8 +100,15 @@ const background = {
   ...vars.dataVisualizationColor,
 };
 
+const decoration = {
+  ...vars.brandColor,
+  ...vars.foregroundColor,
+  transparent: "transparent",
+};
+
 export const statusProperties = {
   color,
+  decoration,
   background: { ...background, currentColor: "currentColor" },
   cursor: {
     pointer: "pointer",
@@ -120,7 +128,7 @@ export const statusProperties = {
   stroke: color,
   textDecoration: ["none", "underline"],
   fill: { ...color, ...background, inherit: "inherit", currentColor: "currentColor" },
-  borderColor: { ...color, transparent: "transparent" },
+  borderColor: color,
   borderStyle: {
     solid: "solid",
     dashed: "dashed",

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -483,7 +483,10 @@ export const underlineTabs: TabsConfig = {
     medium: 16,
     large: 32,
   },
-  lineHeight: 2,
+  lineHeight: {
+    medium: 2,
+    large: 4,
+  },
   lineColor: {
     default: "transparent",
     hover: "foregroundSecondaryInverse",

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -485,7 +485,7 @@ export const underlineTabs: TabsConfig = {
   },
   lineHeight: {
     medium: 2,
-    large: 4,
+    large: 2,
   },
   lineColor: {
     default: "transparent",


### PR DESCRIPTION
Close #423

This PR is breaking since the Navigation's underline color is narrowed down from 
```
brandColor | backgroundColor | interactiveBackgroundColor | outlineColor | dataVisualizationColor 
```
to
```
brandColor | foregroundColor
```
and the Tab's config changes from
````
lineHeight: BentoSprinkles["borderBottomWidth"];
````
to 
```
lineHeight: SizeConfig<number>;
```