### PR TITLE
Honor bento config for MultiValue message in SelectField

### DIFF
--- a/packages/bento-design-system/src/SelectField/SelectField.tsx
+++ b/packages/bento-design-system/src/SelectField/SelectField.tsx
@@ -200,6 +200,7 @@ export function SelectField<A, IsMulti extends boolean = false>(props: Props<A, 
 // because overriding ValueContainer breaks the logic for closing the menu when clicking away.
 // See: https://github.com/JedWatson/react-select/issues/2239#issuecomment-861848975
 function MultiValue<A, IsMulti extends boolean>(props: MultiValueProps<A, IsMulti>) {
+  const inputConfig = useBentoConfig().input;
   const numberOfSelectedOptions = props.getValue().length;
 
   if (props.index > 0 || !props.selectProps.multiValueMessage) {
@@ -210,7 +211,11 @@ function MultiValue<A, IsMulti extends boolean>(props: MultiValueProps<A, IsMult
     return selectComponents.SingleValue(props);
   }
 
-  return <Body size="large">{props.selectProps.multiValueMessage(numberOfSelectedOptions)}</Body>;
+  return (
+    <Body size={inputConfig.fontSize}>
+      {props.selectProps.multiValueMessage(numberOfSelectedOptions)}
+    </Body>
+  );
 }
 
 export type { Props as SelectFieldProps };


### PR DESCRIPTION
We accidentally hardcoded `"large"` which would cause this bug when the `input` config is not `"large"` too:


![2022-11-24 16 25 30](https://user-images.githubusercontent.com/691940/203819736-e3122cd2-0365-4572-9f7d-b4e5cb96502e.gif)

