### PR TITLE
Allow deselecting an option when clicking in SelectField

### DIFF
--- a/packages/bento-design-system/src/SelectField/components.tsx
+++ b/packages/bento-design-system/src/SelectField/components.tsx
@@ -228,7 +228,11 @@ export function Option<B, A extends SelectOption<B>, IsMulti extends boolean>(
       <ListItem
         {...props.data}
         size={props.selectProps.menuSize ?? "medium"}
-        onPress={() => props.selectOption(props.data)}
+        onPress={() =>
+          props.isSelected && !props.selectProps.isMulti
+            ? props.setValue(null as any, "deselect-option")
+            : props.selectOption(props.data)
+        }
         trailingIcon={props.isSelected ? IconCheck : undefined}
         isFocused={props.isFocused}
         isSelected={props.isSelected}


### PR DESCRIPTION
There was no way to deselect a `SelectField` option, since we set `isClearable` to false (because we don't want the default react-select UI that comes with it)

With this change, users can now click the selected option and de-select it.

This only applies to single-select mode, since the multi-select was already working correctly