### PR TITLE
Make placeholder optional on fields

### DIFF
--- a/packages/bento-design-system/src/NumberField/NumberField.tsx
+++ b/packages/bento-design-system/src/NumberField/NumberField.tsx
@@ -10,7 +10,7 @@ import { Field } from "../Field/Field";
 import { NumberInput } from "../NumberInput/NumberInput";
 
 type Props = FieldProps<number | undefined, number> & {
-  placeholder: LocalizedString;
+  placeholder?: LocalizedString;
   isReadOnly?: boolean;
   rightAccessory?: Children;
 } & FormatProps &

--- a/packages/bento-design-system/src/ReadOnlyField/ReadOnlyField.tsx
+++ b/packages/bento-design-system/src/ReadOnlyField/ReadOnlyField.tsx
@@ -68,15 +68,7 @@ export function ReadOnlyField(props: Props) {
     ))
     .exhaustive();
 
-  return (
-    <TextField
-      {...props}
-      onChange={() => {}}
-      placeholder=""
-      isReadOnly
-      rightAccessory={rightAccessory}
-    />
-  );
+  return <TextField {...props} onChange={() => {}} isReadOnly rightAccessory={rightAccessory} />;
 }
 
 export type { Props as ReadOnlyFieldProps };

--- a/packages/bento-design-system/src/SearchBar/SearchBar.tsx
+++ b/packages/bento-design-system/src/SearchBar/SearchBar.tsx
@@ -15,7 +15,7 @@ type Props = AtLeast<Pick<HTMLAttributes<HTMLInputElement>, "aria-label" | "aria
   value: string;
   onChange: (value: string) => unknown;
   onBlur?: () => unknown;
-  placeholder: LocalizedString;
+  placeholder?: LocalizedString;
   disabled?: boolean;
   clearButtonLabel?: LocalizedString;
   autoFocus?: boolean;

--- a/packages/bento-design-system/src/SelectField/SelectField.tsx
+++ b/packages/bento-design-system/src/SelectField/SelectField.tsx
@@ -45,7 +45,7 @@ type SingleProps<A> = {
 
 type Props<A> = {
   menuSize?: ListSize;
-  placeholder: LocalizedString;
+  placeholder?: LocalizedString;
   options: Array<SelectOption<A>>;
   noOptionsMessage?: LocalizedString;
   isReadOnly?: boolean;

--- a/packages/bento-design-system/src/TextArea/TextArea.tsx
+++ b/packages/bento-design-system/src/TextArea/TextArea.tsx
@@ -10,7 +10,7 @@ import { getReadOnlyBackgroundStyle } from "../Field/utils";
 import { getRadiusPropsFromConfig } from "../util/BorderRadiusConfig";
 
 type Props = FieldProps<string> & {
-  placeholder: LocalizedString;
+  placeholder?: LocalizedString;
   isReadOnly?: boolean;
   rows?: number;
 } & Pick<React.HTMLProps<HTMLTextAreaElement>, "onKeyDown" | "onKeyUp">;

--- a/packages/bento-design-system/src/TextField/TextField.tsx
+++ b/packages/bento-design-system/src/TextField/TextField.tsx
@@ -12,7 +12,7 @@ import { getReadOnlyBackgroundStyle } from "../Field/utils";
 import { getRadiusPropsFromConfig } from "../util/BorderRadiusConfig";
 
 type Props = FieldProps<string> & {
-  placeholder: LocalizedString;
+  placeholder?: LocalizedString;
   isReadOnly?: boolean;
   type?: "text" | "email" | "url" | "password";
   rightAccessory?: Children;


### PR DESCRIPTION
We were a bit too strict on requiring a placeholder on every field.
Placeholders are quite controversial in general (see https://www.smashingmagazine.com/2018/06/placeholder-attribute/) and it makes sense for us not to be prescriptive about it.