### PR TITLE
Show rightAccessory in ReadOnlyField

### DIFF
--- a/packages/bento-design-system/src/ReadOnlyField/ReadOnlyField.tsx
+++ b/packages/bento-design-system/src/ReadOnlyField/ReadOnlyField.tsx
@@ -1,5 +1,7 @@
+import { match, __, not } from "ts-pattern";
 import { useBentoConfig } from "../BentoConfigContext";
 import { IconButton } from "../IconButton/IconButton";
+import { Columns } from "../Layout/Columns";
 import { TextField, TextFieldProps } from "../TextField/TextField";
 import { useToast } from "../Toast/useToast";
 import { LocalizedString } from "../util/ConfigurableTypes";
@@ -28,8 +30,9 @@ type Props = Omit<
 export function ReadOnlyField(props: Props) {
   const { showToast } = useToast();
   const config = useBentoConfig().readOnlyField;
+  const inputConfig = useBentoConfig().input;
 
-  const rightAccessory = props.withCopyButton ? (
+  const copyButtonAccessory = props.withCopyButton ? (
     <IconButton
       icon={config.copyIcon}
       onPress={async () => {
@@ -52,6 +55,18 @@ export function ReadOnlyField(props: Props) {
       size={config.copyIconSize}
     />
   ) : undefined;
+
+  const rightAccessory = match([props.rightAccessory, copyButtonAccessory] as const)
+    .with([__.nullish, __.nullish], () => undefined)
+    .with([__.nullish, not(__.nullish)], () => copyButtonAccessory)
+    .with([not(__.nullish), __.nullish], () => props.rightAccessory)
+    .with([not(__.nullish), not(__.nullish)], () => (
+      <Columns space={inputConfig.paddingX} alignY="center">
+        {props.rightAccessory}
+        {copyButtonAccessory}
+      </Columns>
+    ))
+    .exhaustive();
 
   return (
     <TextField

--- a/packages/storybook/stories/Components/ReadonlyField.stories.tsx
+++ b/packages/storybook/stories/Components/ReadonlyField.stories.tsx
@@ -27,3 +27,10 @@ export const WithCopyButton = createStory({
   copyButtonLabel: "Copy to clipboard",
   copySuccessMessage: "Copied to clipboard",
 });
+
+export const WithCopyButtonAndRightAccessory = createStory({
+  withCopyButton: true,
+  copyButtonLabel: "Copy to clipboard",
+  copySuccessMessage: "Copied to clipboard",
+  rightAccessory: "👍",
+});


### PR DESCRIPTION
Fixes #473

It was previously ignored, due to a bug.

This also makes sure we still display the `rightAccessory` in case there is already a copy button