### PR TITLE
#472: Add support for units of measurement on BarChart component

### DIFF
--- a/packages/bento-design-system/src/Charts/BarChart/BarChart.tsx
+++ b/packages/bento-design-system/src/Charts/BarChart/BarChart.tsx
@@ -13,7 +13,8 @@ import { allColors } from "../../util/atoms";
 import { vars } from "../../vars.css";
 import { ChartProps } from "../ChartProps";
 import { legendContent } from "../Legend/Legend";
-import { tooltipContent } from "../Tooltip/Tooltip";
+import { TooltipContent } from "../Tooltip/Tooltip";
+import { ValueFormatter, defaultValueFormatter, ValueType, NameType } from "../utils";
 
 type Props<D extends string, C extends string> = ChartProps & {
   data: Record<D | C, unknown>[];
@@ -22,6 +23,8 @@ type Props<D extends string, C extends string> = ChartProps & {
   hideXAxis?: boolean;
   hideYAxis?: boolean;
   stacked?: boolean;
+  xAxisValueFormatter?: ValueFormatter;
+  yAxisValueFormatter?: ValueFormatter;
 };
 
 export type { Props as BarChartProps };
@@ -45,6 +48,8 @@ export function BarChart<D extends string, C extends string>({
   stacked = false,
   dataColors,
   children,
+  xAxisValueFormatter = defaultValueFormatter,
+  yAxisValueFormatter = defaultValueFormatter,
 }: Props<D, C>) {
   const config = useBentoConfig();
   const colors = (dataColors ?? config.chart.defaultDataColors).map(
@@ -63,11 +68,18 @@ export function BarChart<D extends string, C extends string>({
       debounce={debounce}
     >
       <RechartBarChart data={data}>
-        {!hideXAxis && <XAxis dataKey={dataKey} />}
-        {!hideYAxis && <YAxis />}
+        {!hideXAxis && <XAxis dataKey={dataKey} tickFormatter={xAxisValueFormatter} />}
+        {!hideYAxis && <YAxis tickFormatter={yAxisValueFormatter} />}
         {!hideTooltip && (
-          <Tooltip
-            content={tooltipContent}
+          <Tooltip<ValueType, NameType>
+            content={({ active, payload, label }) => (
+              <TooltipContent
+                active={active}
+                payload={payload}
+                label={label}
+                valueFormatter={yAxisValueFormatter}
+              />
+            )}
             cursor={{ fill: vars.backgroundColor.backgroundSecondary }}
           />
         )}

--- a/packages/bento-design-system/src/Charts/BarChart/BarChart.tsx
+++ b/packages/bento-design-system/src/Charts/BarChart/BarChart.tsx
@@ -13,8 +13,8 @@ import { allColors } from "../../util/atoms";
 import { vars } from "../../vars.css";
 import { ChartProps } from "../ChartProps";
 import { legendContent } from "../Legend/Legend";
-import { TooltipContent } from "../Tooltip/Tooltip";
-import { ValueFormatter, defaultValueFormatter, ValueType, NameType } from "../utils";
+import { tooltipContent } from "../Tooltip/Tooltip";
+import { ValueFormatter } from "../ValueFormatter";
 
 type Props<D extends string, C extends string> = ChartProps & {
   data: Record<D | C, unknown>[];
@@ -48,8 +48,8 @@ export function BarChart<D extends string, C extends string>({
   stacked = false,
   dataColors,
   children,
-  xAxisValueFormatter = defaultValueFormatter,
-  yAxisValueFormatter = defaultValueFormatter,
+  xAxisValueFormatter,
+  yAxisValueFormatter,
 }: Props<D, C>) {
   const config = useBentoConfig();
   const colors = (dataColors ?? config.chart.defaultDataColors).map(
@@ -71,16 +71,10 @@ export function BarChart<D extends string, C extends string>({
         {!hideXAxis && <XAxis dataKey={dataKey} tickFormatter={xAxisValueFormatter} />}
         {!hideYAxis && <YAxis tickFormatter={yAxisValueFormatter} />}
         {!hideTooltip && (
-          <Tooltip<ValueType, NameType>
-            content={({ active, payload, label }) => (
-              <TooltipContent
-                active={active}
-                payload={payload}
-                label={label}
-                valueFormatter={yAxisValueFormatter}
-              />
-            )}
+          <Tooltip
+            content={tooltipContent}
             cursor={{ fill: vars.backgroundColor.backgroundSecondary }}
+            formatter={yAxisValueFormatter}
           />
         )}
         {!hideLegend && <Legend content={legendContent} />}

--- a/packages/bento-design-system/src/Charts/DonutChart/DonutChart.tsx
+++ b/packages/bento-design-system/src/Charts/DonutChart/DonutChart.tsx
@@ -11,7 +11,8 @@ import { bodyRecipe } from "../../Typography/Body/Body.css";
 import { allColors } from "../../util/atoms";
 import { ChartProps } from "../ChartProps";
 import { legendContent } from "../Legend/Legend";
-import { tooltipContent } from "../Tooltip/Tooltip";
+import { TooltipContent } from "../Tooltip/Tooltip";
+import { NameType, ValueType } from "../utils";
 
 type Props<D extends string, C extends string> = ChartProps & {
   data: Record<C | D, unknown>[];
@@ -74,7 +75,13 @@ export function DonutChart<D extends string, C extends string>({
             <Cell key={`cell-${i}`} fill={colors[i % colors.length]} />
           ))}
         </Pie>
-        {!hideTooltip && <Tooltip content={tooltipContent} />}
+        {!hideTooltip && (
+          <Tooltip<ValueType, NameType>
+            content={({ active, payload, label }) => (
+              <TooltipContent active={active} payload={payload} label={label} />
+            )}
+          />
+        )}
         {!hideLegend && <Legend content={legendContent} />}
         {children}
       </RechartPieChart>

--- a/packages/bento-design-system/src/Charts/DonutChart/DonutChart.tsx
+++ b/packages/bento-design-system/src/Charts/DonutChart/DonutChart.tsx
@@ -12,11 +12,13 @@ import { allColors } from "../../util/atoms";
 import { ChartProps } from "../ChartProps";
 import { legendContent } from "../Legend/Legend";
 import { tooltipContent } from "../Tooltip/Tooltip";
+import { ValueFormatter } from "../ValueFormatter";
 
 type Props<D extends string, C extends string> = ChartProps & {
   data: Record<C | D, unknown>[];
   category: C;
   dataKey: D;
+  tooltipFormatter?: ValueFormatter;
 };
 
 export type { Props as DonutChartProps };
@@ -37,6 +39,7 @@ export function DonutChart<D extends string, C extends string>({
   debounce,
   dataColors,
   children,
+  tooltipFormatter,
 }: Props<D, C>) {
   const config = useBentoConfig();
   const colors = (dataColors ?? config.chart.defaultDataColors).map(
@@ -74,7 +77,7 @@ export function DonutChart<D extends string, C extends string>({
             <Cell key={`cell-${i}`} fill={colors[i % colors.length]} />
           ))}
         </Pie>
-        {!hideTooltip && <Tooltip content={tooltipContent} />}
+        {!hideTooltip && <Tooltip content={tooltipContent} formatter={tooltipFormatter} />}
         {!hideLegend && <Legend content={legendContent} />}
         {children}
       </RechartPieChart>

--- a/packages/bento-design-system/src/Charts/DonutChart/DonutChart.tsx
+++ b/packages/bento-design-system/src/Charts/DonutChart/DonutChart.tsx
@@ -11,8 +11,7 @@ import { bodyRecipe } from "../../Typography/Body/Body.css";
 import { allColors } from "../../util/atoms";
 import { ChartProps } from "../ChartProps";
 import { legendContent } from "../Legend/Legend";
-import { TooltipContent } from "../Tooltip/Tooltip";
-import { NameType, ValueType } from "../utils";
+import { tooltipContent } from "../Tooltip/Tooltip";
 
 type Props<D extends string, C extends string> = ChartProps & {
   data: Record<C | D, unknown>[];
@@ -75,13 +74,7 @@ export function DonutChart<D extends string, C extends string>({
             <Cell key={`cell-${i}`} fill={colors[i % colors.length]} />
           ))}
         </Pie>
-        {!hideTooltip && (
-          <Tooltip<ValueType, NameType>
-            content={({ active, payload, label }) => (
-              <TooltipContent active={active} payload={payload} label={label} />
-            )}
-          />
-        )}
+        {!hideTooltip && <Tooltip content={tooltipContent} />}
         {!hideLegend && <Legend content={legendContent} />}
         {children}
       </RechartPieChart>

--- a/packages/bento-design-system/src/Charts/LineChart/LineChart.tsx
+++ b/packages/bento-design-system/src/Charts/LineChart/LineChart.tsx
@@ -12,7 +12,8 @@ import { bodyRecipe } from "../../Typography/Body/Body.css";
 import { allColors } from "../../util/atoms";
 import { ChartProps } from "../ChartProps";
 import { legendContent } from "../Legend/Legend";
-import { tooltipContent } from "../Tooltip/Tooltip";
+import { TooltipContent } from "../Tooltip/Tooltip";
+import { NameType, ValueType } from "../utils";
 
 type Props<D extends string, C extends string> = ChartProps & {
   data: Record<D | C, unknown>[];
@@ -83,7 +84,13 @@ export function LineChart<D extends string, C extends string>({
         ))}
         {!hideXAxis && <XAxis dataKey={dataKey} />}
         {!hideYAxis && <YAxis />}
-        {!hideTooltip && <Tooltip content={tooltipContent} />}
+        {!hideTooltip && (
+          <Tooltip<ValueType, NameType>
+            content={({ active, payload, label }) => (
+              <TooltipContent active={active} payload={payload} label={label} />
+            )}
+          />
+        )}
         {!hideLegend && <Legend content={legendContent} />}
         {children}
       </RechartLineChart>

--- a/packages/bento-design-system/src/Charts/LineChart/LineChart.tsx
+++ b/packages/bento-design-system/src/Charts/LineChart/LineChart.tsx
@@ -12,8 +12,7 @@ import { bodyRecipe } from "../../Typography/Body/Body.css";
 import { allColors } from "../../util/atoms";
 import { ChartProps } from "../ChartProps";
 import { legendContent } from "../Legend/Legend";
-import { TooltipContent } from "../Tooltip/Tooltip";
-import { NameType, ValueType } from "../utils";
+import { tooltipContent } from "../Tooltip/Tooltip";
 
 type Props<D extends string, C extends string> = ChartProps & {
   data: Record<D | C, unknown>[];
@@ -84,13 +83,7 @@ export function LineChart<D extends string, C extends string>({
         ))}
         {!hideXAxis && <XAxis dataKey={dataKey} />}
         {!hideYAxis && <YAxis />}
-        {!hideTooltip && (
-          <Tooltip<ValueType, NameType>
-            content={({ active, payload, label }) => (
-              <TooltipContent active={active} payload={payload} label={label} />
-            )}
-          />
-        )}
+        {!hideTooltip && <Tooltip content={tooltipContent} />}
         {!hideLegend && <Legend content={legendContent} />}
         {children}
       </RechartLineChart>

--- a/packages/bento-design-system/src/Charts/LineChart/LineChart.tsx
+++ b/packages/bento-design-system/src/Charts/LineChart/LineChart.tsx
@@ -13,6 +13,7 @@ import { allColors } from "../../util/atoms";
 import { ChartProps } from "../ChartProps";
 import { legendContent } from "../Legend/Legend";
 import { tooltipContent } from "../Tooltip/Tooltip";
+import { ValueFormatter } from "../ValueFormatter";
 
 type Props<D extends string, C extends string> = ChartProps & {
   data: Record<D | C, unknown>[];
@@ -29,6 +30,8 @@ type Props<D extends string, C extends string> = ChartProps & {
     | "step"
     | "stepBefore"
     | "stepAfter";
+  xAxisValueFormatter?: ValueFormatter;
+  yAxisValueFormatter?: ValueFormatter;
 };
 
 export type { Props as LineChartProps };
@@ -52,6 +55,8 @@ export function LineChart<D extends string, C extends string>({
   lineType = "monotone",
   dataColors,
   children,
+  xAxisValueFormatter,
+  yAxisValueFormatter,
 }: Props<D, C>) {
   const config = useBentoConfig();
   const colors = (dataColors ?? config.chart.defaultDataColors).map(
@@ -81,9 +86,9 @@ export function LineChart<D extends string, C extends string>({
             dot={false}
           />
         ))}
-        {!hideXAxis && <XAxis dataKey={dataKey} />}
-        {!hideYAxis && <YAxis />}
-        {!hideTooltip && <Tooltip content={tooltipContent} />}
+        {!hideXAxis && <XAxis dataKey={dataKey} tickFormatter={xAxisValueFormatter} />}
+        {!hideYAxis && <YAxis tickFormatter={yAxisValueFormatter} />}
+        {!hideTooltip && <Tooltip content={tooltipContent} formatter={yAxisValueFormatter} />}
         {!hideLegend && <Legend content={legendContent} />}
         {children}
       </RechartLineChart>

--- a/packages/bento-design-system/src/Charts/Tooltip/Tooltip.tsx
+++ b/packages/bento-design-system/src/Charts/Tooltip/Tooltip.tsx
@@ -3,21 +3,14 @@ import { Box } from "../../Box/Box";
 import { Column, Columns } from "../../Layout/Columns";
 import { Stack } from "../../Layout/Stack";
 import { Body } from "../../Typography/Body/Body";
-import { NameType, ValueFormatter, ValueType } from "../utils";
+import { NameType, ValueType } from "../ValueFormatter";
 
-type TooltipProps<TValue extends ValueType, TName extends NameType> = RechartsTooltipProps<
-  TValue,
-  TName
-> & {
-  valueFormatter?: ValueFormatter;
-};
-
-export function TooltipContent<TValue extends ValueType, TName extends NameType>({
+export const tooltipContent = <TValue extends ValueType, TName extends NameType>({
   active,
   payload = [],
   label,
-  valueFormatter,
-}: TooltipProps<TValue, TName>) {
+  formatter,
+}: RechartsTooltipProps<TValue, TName>) => {
   if (!active || payload.length === 0) {
     return null;
   }
@@ -34,18 +27,25 @@ export function TooltipContent<TValue extends ValueType, TName extends NameType>
       <Stack space={8}>
         <Body size="medium">{label}</Body>
         <Stack space={4}>
-          {payload.map(({ value, name, color }) => (
-            <Columns key={name} space={4} alignY="center">
-              <Column width="content">
-                <Box height={16} width={16} borderRadius={4} style={{ backgroundColor: color }} />
-              </Column>
-              <Body size="small">{`${name}: ${
-                valueFormatter && value !== undefined ? valueFormatter(value) : value
-              }`}</Body>
-            </Columns>
-          ))}
+          {payload.map(({ value, name, color, payload: item }, index) => {
+            const formatterResult =
+              formatter && name && value ? formatter(value, name, item, index, payload) : value;
+            const formattedText = Array.isArray(formatterResult)
+              ? `${formatterResult[1]}: ${formatterResult[0]}`
+              : typeof formatterResult === "string" || typeof formatterResult === "number"
+              ? `${name}: ${formatterResult}`
+              : `${name}: ${value}`;
+            return (
+              <Columns key={name} space={4} alignY="center">
+                <Column width="content">
+                  <Box height={16} width={16} borderRadius={4} style={{ backgroundColor: color }} />
+                </Column>
+                <Body size="small">{formattedText}</Body>
+              </Columns>
+            );
+          })}
         </Stack>
       </Stack>
     </Box>
   );
-}
+};

--- a/packages/bento-design-system/src/Charts/Tooltip/Tooltip.tsx
+++ b/packages/bento-design-system/src/Charts/Tooltip/Tooltip.tsx
@@ -3,15 +3,21 @@ import { Box } from "../../Box/Box";
 import { Column, Columns } from "../../Layout/Columns";
 import { Stack } from "../../Layout/Stack";
 import { Body } from "../../Typography/Body/Body";
+import { NameType, ValueFormatter, ValueType } from "../utils";
 
-type ValueType = number | string;
-type NameType = number | string;
+type TooltipProps<TValue extends ValueType, TName extends NameType> = RechartsTooltipProps<
+  TValue,
+  TName
+> & {
+  valueFormatter?: ValueFormatter;
+};
 
-export const tooltipContent = <TValue extends ValueType, TName extends NameType>({
+export function TooltipContent<TValue extends ValueType, TName extends NameType>({
   active,
   payload = [],
   label,
-}: RechartsTooltipProps<TValue, TName>) => {
+  valueFormatter,
+}: TooltipProps<TValue, TName>) {
   if (!active || payload.length === 0) {
     return null;
   }
@@ -33,11 +39,13 @@ export const tooltipContent = <TValue extends ValueType, TName extends NameType>
               <Column width="content">
                 <Box height={16} width={16} borderRadius={4} style={{ backgroundColor: color }} />
               </Column>
-              <Body size="small">{`${name}: ${value}`}</Body>
+              <Body size="small">{`${name}: ${
+                valueFormatter && value !== undefined ? valueFormatter(value) : value
+              }`}</Body>
             </Columns>
           ))}
         </Stack>
       </Stack>
     </Box>
   );
-};
+}

--- a/packages/bento-design-system/src/Charts/ValueFormatter.ts
+++ b/packages/bento-design-system/src/Charts/ValueFormatter.ts
@@ -1,0 +1,4 @@
+export type NameType = number | string;
+export type ValueType = number | string;
+
+export type ValueFormatter = (value: ValueType) => string;

--- a/packages/bento-design-system/src/Charts/index.ts
+++ b/packages/bento-design-system/src/Charts/index.ts
@@ -3,3 +3,4 @@ export * from "./ChartProps";
 export * from "./Config";
 export * from "./DonutChart/DonutChart";
 export * from "./LineChart/LineChart";
+export * from "./ValueFormatter";

--- a/packages/bento-design-system/src/Charts/utils.ts
+++ b/packages/bento-design-system/src/Charts/utils.ts
@@ -1,6 +1,0 @@
-export type ValueType = number | string;
-export type NameType = number | string;
-
-export type ValueFormatter = (value: ValueType) => string;
-
-export const defaultValueFormatter: ValueFormatter = (value: ValueType) => value.toString();

--- a/packages/bento-design-system/src/Charts/utils.ts
+++ b/packages/bento-design-system/src/Charts/utils.ts
@@ -1,0 +1,6 @@
+export type ValueType = number | string;
+export type NameType = number | string;
+
+export type ValueFormatter = (value: ValueType) => string;
+
+export const defaultValueFormatter: ValueFormatter = (value: ValueType) => value.toString();

--- a/packages/storybook/stories/Components/Charts/BarChart.stories.tsx
+++ b/packages/storybook/stories/Components/Charts/BarChart.stories.tsx
@@ -63,3 +63,7 @@ const { defaultExport, createStory } = createComponentStories({
 export default defaultExport;
 
 export const barChart = createStory({});
+
+export const barChartWithYAxisFormatter = createStory({
+  yAxisValueFormatter: (value: number | string) => `$${value.toString()}`,
+});

--- a/packages/storybook/stories/Components/Charts/BarChart.stories.tsx
+++ b/packages/storybook/stories/Components/Charts/BarChart.stories.tsx
@@ -64,6 +64,10 @@ export default defaultExport;
 
 export const barChart = createStory({});
 
+export const barChartWithXAxisFormatter = createStory({
+  xAxisValueFormatter: (value: number | string) => `${value.toString().replace("Page ", "")}`,
+});
+
 export const barChartWithYAxisFormatter = createStory({
   yAxisValueFormatter: (value: number | string) => `$${value.toString()}`,
 });

--- a/packages/storybook/stories/Components/Charts/DonutChart.stories.tsx
+++ b/packages/storybook/stories/Components/Charts/DonutChart.stories.tsx
@@ -43,3 +43,7 @@ const { defaultExport, createStory } = createComponentStories({
 export default defaultExport;
 
 export const donutChart = createStory({});
+
+export const donutChartWithTooltipFormatter = createStory({
+  tooltipFormatter: (value: number | string) => `$${value}`,
+});

--- a/packages/storybook/stories/Components/Charts/LineChart.stories.tsx
+++ b/packages/storybook/stories/Components/Charts/LineChart.stories.tsx
@@ -63,3 +63,11 @@ const { defaultExport, createStory } = createComponentStories({
 export default defaultExport;
 
 export const lineChart = createStory({});
+
+export const lineChartWithXAxisFormatter = createStory({
+  xAxisValueFormatter: (value: number | string) => `${value.toString().replace("Page ", "")}`,
+});
+
+export const lineChartWithYAxisFormatter = createStory({
+  yAxisValueFormatter: (value: number | string) => `$${value}`,
+});


### PR DESCRIPTION
Closes #472

The request was only to implement support for units of measurement. This proposed solution allows users to define a generic formatter for values on both X and Y axis, to avoid having to differentiate between pre- and post-fixed units.
~~Additionally, this solution is only implemented for the `BarChart` component, since that was the request, but can easily be extended to the `DonutChart` (where it may be only relevant for tooltips) and `LineChart` components.~~