### PR TITLE
ButtonLink Avoid passing "icon" to the link component

### DIFF
--- a/packages/bento-design-system/src/Button/ButtonLink.tsx
+++ b/packages/bento-design-system/src/Button/ButtonLink.tsx
@@ -28,6 +28,7 @@ export function ButtonLink({
   isDisabled,
   label,
   active = false,
+  icon,
   ...props
 }: Props) {
   const config = useBentoConfig().button;
@@ -59,9 +60,9 @@ export function ButtonLink({
       borderRadius={config.radius}
     >
       <Columns space={config.internalSpacing} alignY="center">
-        {props.icon && (
+        {icon && (
           <Column width="content">
-            {props.icon({
+            {icon({
               size: config.iconSize[size],
               color: "inherit",
             })}


### PR DESCRIPTION
When passing `icon` to `ButtonLink` we accidentally spread the `icon` prop to the link component (which defaults to `<a>`), resulting in a warning like:

```
Warning: Invalid value for prop `icon` on <a> tag. Either remove it from the element, or pass a string or number value to keep it in the DOM. For details, see https://reactjs.org/link/attribute-behavior 
    at a
    ...
```