### PR TITLE
Allow Body typography for Feedback's medium title

### DIFF
--- a/packages/bento-design-system/src/Feedback/Config.ts
+++ b/packages/bento-design-system/src/Feedback/Config.ts
@@ -14,7 +14,7 @@ export type FeedbackConfig = {
   negativeIllustration: (props: IllustrationProps) => Children;
   illustrationSize: SizeConfig<IllustrationProps["size"]>;
   title: {
-    medium: TitleProps["size"];
+    medium: { kind: "title"; size: TitleProps["size"] } | { kind: "body"; size: BodyProps["size"] };
     large:
       | { kind: "display"; size: DisplayProps["size"] }
       | { kind: "title"; size: TitleProps["size"] }

--- a/packages/bento-design-system/src/Feedback/Feedback.tsx
+++ b/packages/bento-design-system/src/Feedback/Feedback.tsx
@@ -4,6 +4,7 @@ import { Title } from "../Typography/Title/Title";
 import { Headline } from "../Typography/Headline/Headline";
 import type { FeedbackConfig } from "./Config";
 import { useBentoConfig } from "../BentoConfigContext";
+import { match } from "ts-pattern";
 
 type Status = "positive" | "negative";
 export type FeedbackSize = "medium" | "large";
@@ -80,35 +81,41 @@ export function Feedback({
 }
 
 function renderTitle(size: FeedbackSize, title: LocalizedString, config: FeedbackConfig) {
-  switch (size) {
-    case "medium":
-      return (
-        <Title size={config.title.medium} align="center">
-          {title}
-        </Title>
-      );
-    case "large":
-      switch (config.title.large.kind) {
-        case "display":
-          return (
-            <Display size={config.title.large.size} align="center">
-              {title}
-            </Display>
-          );
-        case "title":
-          return (
-            <Title size={config.title.large.size} align="center">
-              {title}
-            </Title>
-          );
-        case "headline":
-          return (
-            <Headline size={config.title.large.size} align="center">
-              {title}
-            </Headline>
-          );
-      }
-  }
+  return match(size)
+    .with("medium", () =>
+      match(config.title.medium.kind)
+        .with("body", () => (
+          <Body size={config.title.medium.size} align="center">
+            {title}
+          </Body>
+        ))
+        .with("title", () => (
+          <Title size={config.title.medium.size} align="center">
+            {title}
+          </Title>
+        ))
+        .exhaustive()
+    )
+    .with("large", () =>
+      match(config.title.large.kind)
+        .with("display", () => (
+          <Display size={config.title.large.size} align="center">
+            {title}
+          </Display>
+        ))
+        .with("headline", () => (
+          <Headline size={config.title.large.size} align="center">
+            {title}
+          </Headline>
+        ))
+        .with("title", () => (
+          <Title size={config.title.large.size} align="center">
+            {title}
+          </Title>
+        ))
+        .exhaustive()
+    )
+    .exhaustive();
 }
 
 function illustrationElement(

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -204,7 +204,7 @@ export const feedback: FeedbackConfig = {
   positiveIllustration: IllustrationPositive,
   negativeIllustration: IllustrationNegative,
   title: {
-    medium: "large",
+    medium: { kind: "title", size: "large" },
     large: { kind: "display", size: "small" },
   },
   descriptionSize: {


### PR DESCRIPTION
`Feedback` with `Body size="large"` as medium title:
<img width="189" alt="Screenshot 2023-01-13 at 12 27 39" src="https://user-images.githubusercontent.com/26444095/212310312-c66fb22c-2abd-4e0f-90b9-1801412fd153.png">
