### PR TITLE
Input background

### DIFF
--- a/packages/bento-design-system/src/DateField/DateField.tsx
+++ b/packages/bento-design-system/src/DateField/DateField.tsx
@@ -157,6 +157,7 @@ export function DateField(props: Props) {
         borderRadius={inputConfig.radius}
         paddingX={inputConfig.paddingX}
         paddingY={inputConfig.paddingY}
+        background={inputConfig.background}
         className={clsx(
           inputRecipe({ validation: validationState || "notSet" }),
           bodyRecipe({

--- a/packages/bento-design-system/src/DateField/DateField.tsx
+++ b/packages/bento-design-system/src/DateField/DateField.tsx
@@ -12,6 +12,7 @@ import { dateFieldRecipe } from "./DateField.css";
 import clsx from "clsx";
 import { LocalizedString } from "../util/LocalizedString";
 import { useBentoConfig } from "../BentoConfigContext";
+import { getReadOnlyBackgroundStyle } from "../Field/utils";
 
 export type ShortcutProps<Value> = {
   label: LocalizedString;
@@ -157,7 +158,7 @@ export function DateField(props: Props) {
         borderRadius={inputConfig.radius}
         paddingX={inputConfig.paddingX}
         paddingY={inputConfig.paddingY}
-        background={inputConfig.background}
+        background={inputConfig.background.default}
         className={clsx(
           inputRecipe({ validation: validationState || "notSet" }),
           bodyRecipe({
@@ -170,6 +171,7 @@ export function DateField(props: Props) {
             readOnly: props.readOnly,
           }
         )}
+        style={getReadOnlyBackgroundStyle(inputConfig)}
         disabled={props.disabled}
       >
         <Columns space={16} alignY="center">

--- a/packages/bento-design-system/src/Field/Config.ts
+++ b/packages/bento-design-system/src/Field/Config.ts
@@ -27,7 +27,10 @@ export type InputConfig = {
   paddingX: BentoSprinkles["paddingX"];
   paddingY: BentoSprinkles["paddingY"];
   radius: BentoSprinkles["borderRadius"];
-  background: BentoSprinkles["background"];
+  background: {
+    default: BentoSprinkles["background"];
+    readOnly: BentoSprinkles["background"] & string;
+  };
   fontSize: BodyProps["size"];
   passwordShowIcon: (props: IconProps) => Children;
   passwordHideIcon: (props: IconProps) => Children;

--- a/packages/bento-design-system/src/Field/Config.ts
+++ b/packages/bento-design-system/src/Field/Config.ts
@@ -27,6 +27,7 @@ export type InputConfig = {
   paddingX: BentoSprinkles["paddingX"];
   paddingY: BentoSprinkles["paddingY"];
   radius: BentoSprinkles["borderRadius"];
+  background: BentoSprinkles["background"];
   fontSize: BodyProps["size"];
   passwordShowIcon: (props: IconProps) => Children;
   passwordHideIcon: (props: IconProps) => Children;

--- a/packages/bento-design-system/src/Field/Config.ts
+++ b/packages/bento-design-system/src/Field/Config.ts
@@ -4,6 +4,7 @@ import { BodyProps } from "../Typography/Body/Body";
 import { LabelProps } from "../Typography/Label/Label";
 import { Children } from "../util/Children";
 import { TooltipPlacement } from "./FieldProps";
+import { statusProperties } from "../util/atoms";
 
 export type FieldConfig = {
   label: {
@@ -29,7 +30,10 @@ export type InputConfig = {
   radius: BentoSprinkles["borderRadius"];
   background: {
     default: BentoSprinkles["background"];
-    readOnly: BentoSprinkles["background"] & string;
+    // NOTE(gabro): not using BentoSprinkles["background"] because we only want
+    // "plain" values to use directly in CSS and not conditional objects like
+    // { default: ..., hover: ... }
+    readOnly: keyof typeof statusProperties.background;
   };
   fontSize: BodyProps["size"];
   passwordShowIcon: (props: IconProps) => Children;

--- a/packages/bento-design-system/src/Field/Field.css.ts
+++ b/packages/bento-design-system/src/Field/Field.css.ts
@@ -18,7 +18,6 @@ export const inputRecipe = strictRecipe({
       },
     },
     bentoSprinkles({
-      background: "backgroundPrimary",
       boxShadow: {
         disabled: "outlineInputDisabled",
       },

--- a/packages/bento-design-system/src/Field/Field.css.ts
+++ b/packages/bento-design-system/src/Field/Field.css.ts
@@ -1,6 +1,9 @@
+import { createVar } from "@vanilla-extract/css";
 import { bentoSprinkles } from "../internal/sprinkles.css";
 import { strictRecipe } from "../util/strictRecipe";
 import { vars } from "../vars.css";
+
+export const readOnlyBackground = createVar();
 
 export const inputRecipe = strictRecipe({
   base: [
@@ -13,7 +16,7 @@ export const inputRecipe = strictRecipe({
           color: vars.textColor.textDisabled,
         },
         "input&:read-only, textarea&:read-only, &.readOnly, &[readonly]": {
-          background: vars.backgroundColor.backgroundSecondary,
+          background: readOnlyBackground,
         },
       },
     },

--- a/packages/bento-design-system/src/Field/utils.ts
+++ b/packages/bento-design-system/src/Field/utils.ts
@@ -1,0 +1,12 @@
+import { assignInlineVars } from "@vanilla-extract/dynamic";
+import { statusProperties } from "../util/atoms";
+import { InputConfig } from "./Config";
+import { readOnlyBackground } from "./Field.css";
+import { normalizeStatusValue } from "../internal/sprinkles.css";
+
+export function getReadOnlyBackgroundStyle<T extends InputConfig>(config: T) {
+  return assignInlineVars({
+    [readOnlyBackground]:
+      statusProperties.background[normalizeStatusValue(config.background.readOnly).default!],
+  });
+}

--- a/packages/bento-design-system/src/Field/utils.ts
+++ b/packages/bento-design-system/src/Field/utils.ts
@@ -2,11 +2,9 @@ import { assignInlineVars } from "@vanilla-extract/dynamic";
 import { statusProperties } from "../util/atoms";
 import { InputConfig } from "./Config";
 import { readOnlyBackground } from "./Field.css";
-import { normalizeStatusValue } from "../internal/sprinkles.css";
 
 export function getReadOnlyBackgroundStyle<T extends InputConfig>(config: T) {
   return assignInlineVars({
-    [readOnlyBackground]:
-      statusProperties.background[normalizeStatusValue(config.background.readOnly).default!],
+    [readOnlyBackground]: statusProperties.background[config.background.readOnly],
   });
 }

--- a/packages/bento-design-system/src/NumberInput/NumberInput.tsx
+++ b/packages/bento-design-system/src/NumberInput/NumberInput.tsx
@@ -7,6 +7,7 @@ import { bodyRecipe } from "../Typography/Body/Body.css";
 import { FormatProps } from "./FormatProps";
 import { useBentoConfig } from "../BentoConfigContext";
 import { match, not, __ } from "ts-pattern";
+import { getReadOnlyBackgroundStyle } from "../Field/utils";
 
 type Props = {
   inputProps: React.InputHTMLAttributes<HTMLInputElement>;
@@ -103,9 +104,13 @@ export function NumberInput(props: Props) {
         borderRadius={config.radius}
         paddingX={config.paddingX}
         paddingY={config.paddingY}
-        background={config.background}
+        background={config.background.default}
         display="flex"
-        style={{ paddingRight: rightAccessoryWidth, flexGrow: 1 }}
+        style={{
+          paddingRight: rightAccessoryWidth,
+          flexGrow: 1,
+          ...getReadOnlyBackgroundStyle(config),
+        }}
       />
       {rightAccessory && (
         <Box

--- a/packages/bento-design-system/src/NumberInput/NumberInput.tsx
+++ b/packages/bento-design-system/src/NumberInput/NumberInput.tsx
@@ -103,6 +103,7 @@ export function NumberInput(props: Props) {
         borderRadius={config.radius}
         paddingX={config.paddingX}
         paddingY={config.paddingY}
+        background={config.background}
         display="flex"
         style={{ paddingRight: rightAccessoryWidth, flexGrow: 1 }}
       />

--- a/packages/bento-design-system/src/SearchBar/SearchBar.tsx
+++ b/packages/bento-design-system/src/SearchBar/SearchBar.tsx
@@ -8,6 +8,7 @@ import { input } from "./SearchBar.css";
 import { useDefaultMessages } from "../util/useDefaultMessages";
 import { useBentoConfig } from "../BentoConfigContext";
 import { AtLeast } from "../util/AtLeast";
+import { getReadOnlyBackgroundStyle } from "../Field/utils";
 
 type Props = AtLeast<Pick<HTMLAttributes<HTMLInputElement>, "aria-label" | "aria-labelledby">> & {
   value: string;
@@ -100,10 +101,11 @@ export function SearchBar(props: Props) {
             flexGrow: 1,
             paddingLeft: leftAccessoryWidth,
             paddingRight: rightAccessoryWidth,
+            ...getReadOnlyBackgroundStyle(config),
           }}
           borderRadius={config.radius}
           paddingY={config.paddingY}
-          background={config.background}
+          background={config.background.default}
         />
         {rightAccessoryContent && (
           <Box

--- a/packages/bento-design-system/src/SearchBar/SearchBar.tsx
+++ b/packages/bento-design-system/src/SearchBar/SearchBar.tsx
@@ -103,6 +103,7 @@ export function SearchBar(props: Props) {
           }}
           borderRadius={config.radius}
           paddingY={config.paddingY}
+          background={config.background}
         />
         {rightAccessoryContent && (
           <Box

--- a/packages/bento-design-system/src/TextArea/TextArea.tsx
+++ b/packages/bento-design-system/src/TextArea/TextArea.tsx
@@ -6,6 +6,7 @@ import { inputRecipe } from "../Field/Field.css";
 import { FieldProps } from "../Field/FieldProps";
 import { bodyRecipe } from "../Typography/Body/Body.css";
 import { useBentoConfig } from "../BentoConfigContext";
+import { getReadOnlyBackgroundStyle } from "../Field/utils";
 
 type Props = FieldProps<string> & {
   placeholder: LocalizedString;
@@ -48,7 +49,7 @@ export function TextArea(props: Props) {
         borderRadius={config.radius}
         paddingX={config.paddingX}
         paddingY={config.paddingY}
-        background={config.background}
+        background={config.background.default}
         rows={props.rows}
         className={[
           inputRecipe({ validation: validationState || "notSet" }),
@@ -58,6 +59,7 @@ export function TextArea(props: Props) {
             size: config.fontSize,
           }),
         ]}
+        style={getReadOnlyBackgroundStyle(config)}
       />
     </Field>
   );

--- a/packages/bento-design-system/src/TextArea/TextArea.tsx
+++ b/packages/bento-design-system/src/TextArea/TextArea.tsx
@@ -48,6 +48,7 @@ export function TextArea(props: Props) {
         borderRadius={config.radius}
         paddingX={config.paddingX}
         paddingY={config.paddingY}
+        background={config.background}
         rows={props.rows}
         className={[
           inputRecipe({ validation: validationState || "notSet" }),

--- a/packages/bento-design-system/src/TextField/TextField.tsx
+++ b/packages/bento-design-system/src/TextField/TextField.tsx
@@ -87,6 +87,7 @@ export function TextField(props: Props) {
           borderRadius={config.radius}
           paddingX={config.paddingX}
           paddingY={config.paddingY}
+          background={config.background}
           className={[
             inputRecipe({ validation: validationState || "notSet" }),
             bodyRecipe({

--- a/packages/bento-design-system/src/TextField/TextField.tsx
+++ b/packages/bento-design-system/src/TextField/TextField.tsx
@@ -9,6 +9,7 @@ import useDimensions from "react-cool-dimensions";
 import { defaultMessages } from "../../test/util/defaultMessages";
 import { useBentoConfig } from "../BentoConfigContext";
 import { match } from "ts-pattern";
+import { getReadOnlyBackgroundStyle } from "../Field/utils";
 
 type Props = FieldProps<string> & {
   placeholder: LocalizedString;
@@ -87,7 +88,7 @@ export function TextField(props: Props) {
           borderRadius={config.radius}
           paddingX={config.paddingX}
           paddingY={config.paddingY}
-          background={config.background}
+          background={config.background.default}
           className={[
             inputRecipe({ validation: validationState || "notSet" }),
             bodyRecipe({
@@ -96,7 +97,11 @@ export function TextField(props: Props) {
               size: config.fontSize,
             }),
           ]}
-          style={{ paddingRight: rightAccessory ? rightAccessoryWidth : undefined, flexGrow: 1 }}
+          style={{
+            paddingRight: rightAccessory ? rightAccessoryWidth : undefined,
+            flexGrow: 1,
+            ...getReadOnlyBackgroundStyle(config),
+          }}
         />
         {rightAccessory && (
           <Box

--- a/packages/bento-design-system/src/TimeField/TimeField.tsx
+++ b/packages/bento-design-system/src/TimeField/TimeField.tsx
@@ -10,6 +10,7 @@ import { useBentoConfig } from "../BentoConfigContext";
 import { DateSegment } from "./DateSegment";
 import { Time } from "@internationalized/date";
 import { TimeValue } from "@react-types/datepicker";
+import { getReadOnlyBackgroundStyle } from "../Field/utils";
 
 type Props = FieldProps<Time | undefined, Time> & {
   isReadOnly?: boolean;
@@ -73,9 +74,10 @@ export function TimeField(props: Props) {
         borderRadius={config.radius}
         paddingX={config.paddingX}
         paddingY={config.paddingY}
-        background={config.background}
+        background={config.background.default}
         className={inputRecipe({ validation: validationState || "notSet" })}
         disabled={props.disabled}
+        style={getReadOnlyBackgroundStyle(config)}
         {...fieldProps}
       >
         {state.segments.map((segment, i) => (

--- a/packages/bento-design-system/src/TimeField/TimeField.tsx
+++ b/packages/bento-design-system/src/TimeField/TimeField.tsx
@@ -73,6 +73,7 @@ export function TimeField(props: Props) {
         borderRadius={config.radius}
         paddingX={config.paddingX}
         paddingY={config.paddingY}
+        background={config.background}
         className={inputRecipe({ validation: validationState || "notSet" })}
         disabled={props.disabled}
         {...fieldProps}

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -263,7 +263,7 @@ export const input: InputConfig = {
   paddingY: 16,
   fontSize: "large",
   internalSpacing: 16,
-  background: "backgroundPrimary",
+  background: { default: "backgroundPrimary", readOnly: "backgroundSecondary" },
   passwordIconSize: 24,
   passwordShowIcon: IconEye,
   passwordHideIcon: IconEyeClosed,

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -263,6 +263,7 @@ export const input: InputConfig = {
   paddingY: 16,
   fontSize: "large",
   internalSpacing: 16,
+  background: "backgroundPrimary",
   passwordIconSize: 24,
   passwordShowIcon: IconEye,
   passwordHideIcon: IconEyeClosed,


### PR DESCRIPTION
Default background for `NumberInput` as `brandPrimary`:
<img width="365" alt="Screenshot 2023-01-13 at 14 51 46" src="https://user-images.githubusercontent.com/26444095/212335968-b509a6a7-87d1-496e-9425-c2d7a0883f69.png">

Read-only background for `NumberInput` as `brandTertiary`:
<img width="344" alt="Screenshot 2023-01-13 at 14 51 55" src="https://user-images.githubusercontent.com/26444095/212336106-c0004f06-2296-41b1-88c5-e90237716032.png">
