### PR TITLE
Allow Body typography for Chip's label

### DIFF
--- a/packages/bento-design-system/src/Chip/Chip.tsx
+++ b/packages/bento-design-system/src/Chip/Chip.tsx
@@ -1,11 +1,22 @@
 import { FunctionComponent } from "react";
 import { IconProps } from "../Icons/IconProps";
-import { Label, LocalizedString, Columns, Column, Box, IconButton, ChipCustomColors } from "..";
+import {
+  Label,
+  LocalizedString,
+  Columns,
+  Column,
+  Box,
+  IconButton,
+  ChipCustomColors,
+  Body,
+} from "..";
 import { BentoSprinkles } from "../internal";
 import { chip, ellipsedLabel, maxWidth } from "./Chip.css";
 import { useDefaultMessages } from "../util/useDefaultMessages";
 import { assignInlineVars } from "@vanilla-extract/dynamic";
 import { useBentoConfig } from "../BentoConfigContext";
+import { ChipConfig } from "./Config";
+import { match } from "ts-pattern";
 
 type DismissProps =
   | {
@@ -85,8 +96,7 @@ export function Chip({ color, label: _label, icon, maxCharacters, ...dismissProp
             {icon && (
               <Column width="content">{icon({ size: config.iconSize, color: "secondary" })}</Column>
             )}
-
-            <Label size={config.labelSize}>{label}</Label>
+            {renderLabel(label, config)}
           </Columns>
           {dismissProps.onDismiss && (
             <Column width="content">
@@ -104,6 +114,13 @@ export function Chip({ color, label: _label, icon, maxCharacters, ...dismissProp
       </Box>
     </Box>
   );
+}
+
+function renderLabel(label: string | JSX.Element, config: ChipConfig) {
+  return match(config.label)
+    .with({ kind: "body" }, ({ size }) => <Body size={size}>{label}</Body>)
+    .with({ kind: "label" }, ({ size }) => <Label size={size}>{label}</Label>)
+    .exhaustive();
 }
 
 export type { Props as ChipProps };

--- a/packages/bento-design-system/src/Chip/Config.ts
+++ b/packages/bento-design-system/src/Chip/Config.ts
@@ -1,5 +1,6 @@
 import { IconProps } from "../Icons";
 import { BentoSprinkles } from "../internal";
+import { BodyProps } from "../Typography/Body/Body";
 import { LabelProps } from "../Typography/Label/Label";
 import { Children } from "../util/Children";
 import { ChipCustomColors } from "../util/ConfigurableTypes";
@@ -7,7 +8,7 @@ import { ChipCustomColors } from "../util/ConfigurableTypes";
 export type ChipConfig = {
   paddingX: BentoSprinkles["paddingX"];
   paddingY: BentoSprinkles["paddingY"];
-  labelSize: LabelProps["size"];
+  label: { kind: "label"; size: LabelProps["size"] } | { kind: "body"; size: BodyProps["size"] };
   iconSize: IconProps["size"];
   closeIcon: (props: IconProps) => Children;
   closeIconSize: IconProps["size"];

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -160,7 +160,7 @@ export const chart: ChartConfig = {
 export const chip: ChipConfig = {
   paddingX: 8,
   paddingY: 4,
-  labelSize: "small",
+  label: { kind: "label", size: "small" },
   iconSize: 12,
   closeIcon: IconClose,
   closeIconSize: 8,


### PR DESCRIPTION
`Chip` with `Body size="medium"` as label:
<img width="70" alt="Screenshot 2023-01-13 at 16 13 35" src="https://user-images.githubusercontent.com/26444095/212354609-468ae8f7-cf4c-4aba-b814-74e132ac90a4.png">
