### PR TITLE
Allow config of background color for Table's even rows

### DIFF
--- a/packages/bento-design-system/src/Table/Config.ts
+++ b/packages/bento-design-system/src/Table/Config.ts
@@ -10,4 +10,5 @@ export type TableConfig = {
   headerForegroundColor: BentoSprinkles["color"];
   hintPlacement: TooltipPlacement;
   cellTooltipPlacement: TooltipPlacement;
+  evenRowsBackgroundColor: BentoSprinkles["background"];
 };

--- a/packages/bento-design-system/src/Table/Table.css.ts
+++ b/packages/bento-design-system/src/Table/Table.css.ts
@@ -56,10 +56,6 @@ export const cellContainerRecipe = strictRecipe({
     justifyContent: "center",
   }),
   variants: {
-    even: {
-      true: bentoSprinkles({ background: "backgroundSecondary" }),
-      false: bentoSprinkles({ background: "backgroundPrimary" }),
-    },
     firstColumn: {
       true: bentoSprinkles({ paddingLeft: 8 }),
     },

--- a/packages/bento-design-system/src/Table/Table.tsx
+++ b/packages/bento-design-system/src/Table/Table.tsx
@@ -487,14 +487,12 @@ function CellContainer({
   first: boolean;
   last: boolean;
 } & TableCellProps) {
+  const tableConfig = useBentoConfig().table;
   return (
     <Box className={lastLeftSticky && lastLeftStickyColumn} style={style}>
       <Box
-        className={cellContainerRecipe({
-          even: index % 2 === 0,
-          firstColumn: first,
-          lastColumn: last,
-        })}
+        background={index % 2 === 0 ? tableConfig.evenRowsBackgroundColor : "backgroundPrimary"}
+        className={cellContainerRecipe({ firstColumn: first, lastColumn: last })}
         {...props}
       >
         {children}

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -464,6 +464,7 @@ export const table: TableConfig = {
   headerForegroundColor: undefined,
   hintPlacement: "top",
   cellTooltipPlacement: "bottom",
+  evenRowsBackgroundColor: "backgroundSecondary",
 };
 
 export const toast: ToastConfig = {


### PR DESCRIPTION
Table with `backgroundInformative`:
<img width="1240" alt="Screenshot 2023-01-16 at 14 57 56" src="https://user-images.githubusercontent.com/26444095/212695548-6f73e9f8-70b7-49d0-bfd4-ecb0827ec366.png">
