### PR TITLE
Fix arrow position when Tooltip is auto-positioned to the left

### DIFF
--- a/packages/bento-design-system/src/Tooltip/Tooltip.tsx
+++ b/packages/bento-design-system/src/Tooltip/Tooltip.tsx
@@ -36,14 +36,17 @@ export function Tooltip(props: Props) {
   const config = useBentoConfig().tooltip;
   const arrowRef = useRef<HTMLElement | null>(null);
 
-  const commonMiddleware = [shift(), offset(8), arrow({ element: arrowRef })];
+  const commonMiddleware = [shift(), offset(8)];
+  const arrowMiddleware = arrow({ element: arrowRef });
   const floatingProps: UseFloatingProps = props.placement
     ? {
         placement: props.placement,
-        middleware: commonMiddleware.concat([flip()]),
+        middleware: commonMiddleware.concat([flip(), arrowMiddleware]),
       }
     : {
-        middleware: commonMiddleware.concat([autoPlacement()]),
+        // NOTE(gabro): it's important that arrow comes after autoPlacement, otherwise the arrow will be positioned incorrectly
+        // See https://github.com/buildo/bento-design-system/issues/513
+        middleware: commonMiddleware.concat([autoPlacement(), arrowMiddleware]),
       };
   const {
     x,


### PR DESCRIPTION
Before the fix:

<img width="937" alt="image" src="https://user-images.githubusercontent.com/691940/213467438-baf646da-b80d-4c7f-90cd-8ab748489f8d.png">

([playroom link](https://playroom.bento.buildo.io/#?code=N4Igxg9gJgpiBcIA8AVAlgGxgZwATYAcBDMGAXmACYAWAX10gwFcBbAO2woGZaA%2BAHTa5cqCBAwAXNAUHDhkNhJiKy-ECjGTpuFjmxEA5jDWy5EgE5oDR8xQAU5mADMANLgLmIBbAEpcZXlw7UzkRACEIAA9cRycKWPpgADoUjy9seig0QgwiAE9VEDQ2DGKYAFoAIwwIMABrNQEhULkkAEkFAHUiczZig3w0AC9yYABGADZ6AHomlpFpiMi5uR9aU1nTUXEpGWb5CEVlCUKNHe1dbH0jE33cCysbe1i3NO8-AKCQ1qWY53jnIkUkk3hlcFkcvlCsVSmwKtVag0QCt5u0uj0%2BmwBthhqNJjMUa1FlFCWsNittlo9qEFEoVGozlSdHpDMYQN8HtYYLZgA5nK9PO9-IFgndhEhfrEAU4galBWCIQRcgU1DCylUavVGt9QmjDt1ev1BiMKPjcJsxQslqT1s0LeLGbtvrTjqdNLtmVdWbdQpynryXu55R8RTrwlE-nFgAlcMk5elMtklVDVSV1Qitciw%2BKOvqMUacSbxlNzYTxcTlt8yXaKY7pM7DnSTgz3RcWTd2Xc-dznvyg%2BkQ19LRKI1Lo4DY8DQYnISqimm4RrEdrLTn0Yasca8SX7S0kBWbeStnXqXIXfT1K2CJ7rmyOZYuTy%2Ba5%2B0LPqLUZL-uOZZP494Z2TOc1UXDMkTLVpczYA1MWxXFTR3CD92tKtbWEXdKSdO5z2bS9zmvS5bx9MwH39Z8BQHYUh0-UdvxjOMQXlQDlWhBd4U1cDsxEKCYILeDiwJMNkJJVCj2aTD62wxtXRbfCb29TtfVInsAz7UFBw-PcvyjeipyY8EkxY1NYXY5cs1Xbj11grcEME4cD1EmtjyvBsjgvE95I7e9HhU8jX18KjNN1bTpVlRiEwM2dWJMpdMwgtc8w3OCizNXddQcu5q3Qpp93QLBsCaEAXBAAB3NAoAkAALbAEAAbQAXVoIA))

After the fix:

<img width="948" alt="image" src="https://user-images.githubusercontent.com/691940/213467286-f2502634-4530-4d86-8e20-c2b3b3531595.png">

([playroom link](https://bento-playroom-git-fix-513-buildo1.vercel.app/#?code=N4Igxg9gJgpiBcIA8AVAlgGxgZwATYAcBDMGAXmACYAWAX10gwFcBbAO2woGZaA%2BAHTa5cqCBAwAXNAUHDhkNhJiKy-ECjGTpuFjmxEA5jDWy5EgE5oDR8xQAU5mADMANLgLmIBbAEpcZXlw7UzkRACEIAA9cRycKWPpgADoUjy9seig0QgwiAE9VEDQ2DGKYAFoAIwwIMABrNQEhULkkAEkFAHUiczZig3w0AC9yYABGADZ6AHomlpFpiMi5uR9aU1nTUXEpGWb5CEVlCUKNHe1dbH0jE33cCysbe1i3NO8-AKCQ1qWY53jnIkUkk3hlcFkcvlCsVSmwKtVag0QCt5u0uj0%2BmwBthhqNJjMUa1FlFCWsNittlo9qEFEoVGozlSdHpDMYQN8HtYYLZgA5nK9PO9-IFgndhEhfrEAU4galBWCIQRcgU1DCylUavVGt9QmjDt1ev1BiMKPjcJsxQslqT1s0LeLGbtvrTjqdNLtmVdWbdQpynryXu55R8RTrwlE-nFgAlcMk5elMtklVDVSV1Qitciw%2BKOvqMUacSbxlNzYTxcTlt8yXaKY7pM7DnSTgz3RcWTd2Xc-dznvyg%2BkQ19LRKI1Lo4DY8DQYnISqimm4RrEdrLTn0Yasca8SX7S0kBWbeStnXqXIXfT1K2CJ7rmyOZYuTy%2Ba5%2B0LPqLUZL-uOZZP494Z2TOc1UXDMkTLVpczYA1MWxXFTR3CD92tKtbWEXdKSdO5z2bS9zmvS5bx9MwH39Z8BQHYUh0-UdvxjOMQXlQDlWhBd4U1cDsxEKCYILeDiwJMNkJJVCj2aTD62wxtXRbfCb29TtfVInsAz7UFBw-PcvyjeipyY8EkxY1NYXY5cs1Xbj11grcEME4cD1EmtjyvBsjgvE95I7e9HhU8jX18KjNN1bTpVlRiEwM2dWJMpdMwgtc8w3OCizNXddQcu5q3Qpp93QLBsCaEAXBAAB3NAoAkAALbAEAAbQAXVoIA))
