### PR TITLE
#532: Add config to FileUploaderField to customise button and allow external control of loading status

### DIFF
--- a/packages/bento-design-system/src/FileUploaderField/Config.ts
+++ b/packages/bento-design-system/src/FileUploaderField/Config.ts
@@ -1,3 +1,6 @@
+import { ButtonProps } from "..";
+
 export type FileUploaderFieldConfig = {
   defaultHeight: string | number;
+  buttonKind: ButtonProps["kind"];
 };

--- a/packages/bento-design-system/src/FileUploaderField/FileUploaderField.tsx
+++ b/packages/bento-design-system/src/FileUploaderField/FileUploaderField.tsx
@@ -144,7 +144,11 @@ export function FileUploaderField<E extends string>({
 }: Props<E>) {
   const config = useBentoConfig().fileUploaderField;
   const height = height_ ?? config.defaultHeight;
+
   const [uploading, setUploading] = useState<boolean>(isUploading ?? false);
+  useEffect(() => {
+    isUploading !== undefined && setUploading(isUploading);
+  }, [isUploading]);
 
   // note(Fede): useDropzone already exposes a `isDragActive` flag, but it is true
   // only when a file is dragged over the component, not the whole window, which is what we prefer.

--- a/packages/bento-design-system/src/FileUploaderField/FileUploaderField.tsx
+++ b/packages/bento-design-system/src/FileUploaderField/FileUploaderField.tsx
@@ -34,7 +34,7 @@ const errorCodes = [
 type KnownDropzoneErrorCode = typeof errorCodes[number];
 
 export type ErrorCode =
-  | `${DropzoneErrorCode}`
+  | `${KnownDropzoneErrorCode}`
   | "generic-error"
   | "wrong-structure"
   | "unable-to-read";
@@ -42,11 +42,6 @@ export type ErrorCode =
 function isDropzoneKnownError(error: string): error is KnownDropzoneErrorCode {
   return errorCodes.find((c) => c === error) !== undefined;
 }
-
-export type ErrorMessages<E extends string> = Record<
-  E | ErrorCode,
-  Children | ((file: File | undefined) => Children)
->;
 
 export type FileUploaderTexts = {
   title: LocalizedString;
@@ -100,6 +95,10 @@ type Props<E extends string> = {
    * The field height
    */
   height?: string | number;
+  /**
+   * A parameter that allows external control of the uploading status.
+   */
+  isUploading?: boolean;
 } & Omit<FieldProps<FileResult<E> | undefined>, "assistiveText" | "issues">;
 
 export type { Props as FileUploaderProps };
@@ -141,10 +140,11 @@ export function FileUploaderField<E extends string>({
   maxFileSize,
   allowedFileTypes,
   height: height_,
+  isUploading,
 }: Props<E>) {
   const config = useBentoConfig().fileUploaderField;
   const height = height_ ?? config.defaultHeight;
-  const [uploading, setUploading] = useState<boolean>(false);
+  const [uploading, setUploading] = useState<boolean>(isUploading ?? false);
 
   // note(Fede): useDropzone already exposes a `isDragActive` flag, but it is true
   // only when a file is dragged over the component, not the whole window, which is what we prefer.
@@ -340,7 +340,7 @@ export function FileUploaderField<E extends string>({
                 </Stack>
               </ContentBlock>
               <Button
-                kind="solid"
+                kind={config.buttonKind}
                 hierarchy="secondary"
                 label={texts.uploadButtonLabel}
                 onPress={open}

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -251,6 +251,7 @@ export const field: FieldConfig = {
 
 export const fileUploaderField: FileUploaderFieldConfig = {
   defaultHeight: "8rem",
+  buttonKind: "solid",
 };
 
 export const inlineLoader: InlineLoaderConfig = {

--- a/packages/storybook/stories/Components/FileUploaderField.stories.tsx
+++ b/packages/storybook/stories/Components/FileUploaderField.stories.tsx
@@ -8,7 +8,7 @@ const { defaultExport, createControlledStory } = createComponentStories({
 
 export default defaultExport;
 
-export const fileUploaderField = createControlledStory(undefined, {
+const fileUploaderProps = {
   label: "Upload a file",
   allowedFileTypes: {
     "text/csv": [".csv"],
@@ -21,10 +21,21 @@ export const fileUploaderField = createControlledStory(undefined, {
     uploadAgainMessage: "Upload another file: ",
     uploadingMessage: "Uploading...",
     uploadButtonLabel: "Choose a file",
-    assistiveTextFileTypes: (fileTypes) =>
+    assistiveTextFileTypes: (fileTypes?: Record<string, string[]>) =>
       fileTypes ? "Allowed file types: " + Object.values(fileTypes).flat().join(", ") : "",
-    assistiveTextMaxSize: (maxSizeMb) => (maxSizeMb ? "Max file size: " + maxSizeMb + "MB" : ""),
+    assistiveTextMaxSize: (maxSizeMb?: number) =>
+      maxSizeMb ? "Max file size: " + maxSizeMb + "MB" : "",
   },
   renderIssue: () => "error",
   maxFileSize: 1000,
+};
+
+export const fileUploaderField = createControlledStory(undefined, fileUploaderProps);
+
+export const loading = createControlledStory(undefined, {
+  ...fileUploaderProps,
+  isUploading: true,
 });
+loading.parameters = {
+  chromatic: { pauseAnimationAtEnd: true },
+};

--- a/packages/storybook/stories/Components/FileUploaderField.stories.tsx
+++ b/packages/storybook/stories/Components/FileUploaderField.stories.tsx
@@ -1,4 +1,5 @@
-import { FileUploaderField } from "..";
+import { StoryFn } from "@storybook/react";
+import { FileUploaderField, BentoConfigProvider } from "..";
 import { createComponentStories } from "../util";
 
 const { defaultExport, createControlledStory } = createComponentStories({
@@ -39,3 +40,18 @@ export const loading = createControlledStory(undefined, {
 loading.parameters = {
   chromatic: { pauseAnimationAtEnd: true },
 };
+
+export const withOutlineButton = createControlledStory(undefined, fileUploaderProps);
+withOutlineButton.decorators = [
+  (Story: StoryFn) => (
+    <BentoConfigProvider
+      value={{
+        fileUploaderField: {
+          buttonKind: "outline",
+        },
+      }}
+    >
+      <Story />
+    </BentoConfigProvider>
+  ),
+];

--- a/packages/storybook/stories/Components/FileUploaderField.stories.tsx
+++ b/packages/storybook/stories/Components/FileUploaderField.stories.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { StoryFn } from "@storybook/react";
-import { FileUploaderField, BentoConfigProvider } from "..";
+import { FileUploaderField, BentoConfigProvider, Button, Stack } from "..";
 import { createComponentStories } from "../util";
 
 const { defaultExport, createControlledStory } = createComponentStories({
@@ -33,11 +34,27 @@ const fileUploaderProps = {
 
 export const fileUploaderField = createControlledStory(undefined, fileUploaderProps);
 
-export const loading = createControlledStory(undefined, {
-  ...fileUploaderProps,
-  isUploading: true,
-});
-loading.parameters = {
+export const Loading = () => {
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <Stack space={16}>
+      <FileUploaderField
+        {...fileUploaderProps}
+        value={undefined}
+        onChange={() => {}}
+        isUploading={loading}
+      />
+      <Button
+        kind="solid"
+        hierarchy="primary"
+        label={loading ? "Stop loading" : "Start loading"}
+        onPress={() => setLoading(!loading)}
+      />
+    </Stack>
+  );
+};
+Loading.parameters = {
   chromatic: { pauseAnimationAtEnd: true },
 };
 

--- a/packages/storybook/stories/Components/FileUploaderField.stories.tsx
+++ b/packages/storybook/stories/Components/FileUploaderField.stories.tsx
@@ -54,9 +54,6 @@ export const Loading = () => {
     </Stack>
   );
 };
-Loading.parameters = {
-  chromatic: { pauseAnimationAtEnd: true },
-};
 
 export const withOutlineButton = createControlledStory(undefined, fileUploaderProps);
 withOutlineButton.decorators = [


### PR DESCRIPTION
Closes #532

## Test Plan
✅ Button kind is configurable correctly
✅ `isUploading` prop correctly forces the component in uploading status