### PR TITLE
fix(docs): Fix typos in Quick Start > Project Structure section

### DIFF
--- a/packages/website/docs/02-Getting Started/03-project-structure.mdx
+++ b/packages/website/docs/02-Getting Started/03-project-structure.mdx
@@ -102,7 +102,7 @@ export default defineConfig({
   inject: ["./jsxShim.ts"],
   // Include here the css files coming from external dependencies, which we
   // recommend to bundle in your design system package.
-  noExternals: [
+  noExternal: [
     "@buildo/bento-design-system/lib/index.css",
     // e.g. here's how to include fonts from Fontsource, a popular library for self-hosting fonts
     // "@fontsource",
@@ -138,7 +138,7 @@ my-project/
 ├─ packages/
 │  ├─ design-system/
 │  │  ├─ src/
-│  │  │  ├─ index.tsx
+│  │  │  ├─ index.ts
 │  │  ├─ package.json
 │  │  ├─ tsup.config.ts
 │  │  ├─ jsxShim.ts
@@ -147,11 +147,11 @@ my-project/
 ├─ pnpm-workspaces.yaml
 ```
 
-`packages/design-system/src/index.tsx` is where you configure and export Bento components.
+`packages/design-system/src/index.ts` is where you configure and export Bento components.
 
 Your `index.ts` will look something like this:
 
-```tsx title="my-project/packages/design-system/src/index.tsx"
+```tsx title="my-project/packages/design-system/src/index.ts"
 import { createBentoProvider } from "@buildo/bento-design-system";
 
 // Export the Bento components you want to use in your app


### PR DESCRIPTION
Fix a couple of typos in the `Quick Start` section of the documentation:
-  `noExternals` => `noExternal` as the correct option is without the `s`
- `index.tsx` => `index.ts` as there is no JSX syntax in the index file. This is debatable, but there is inconsistency across the page: if we want to keep `index.tsx`, an occurrence of `index.ts` should be updated.


# Test Plan
Run the website locally
![Screen Shot 2023-02-26 at 22 04 58](https://user-images.githubusercontent.com/16003164/221437659-d8a99280-3de9-4c2f-aa9d-d890d306679b.png)
![Screen Shot 2023-02-26 at 22 05 14](https://user-images.githubusercontent.com/16003164/221437660-47118c4f-2e30-4b94-8a62-51a8dc93c085.png)
