### PR TITLE
fix(docs): Add disclaimer for vanillaExtractPlugin incompatible type

### DIFF
--- a/packages/website/docs/02-Getting Started/03-project-structure.mdx
+++ b/packages/website/docs/02-Getting Started/03-project-structure.mdx
@@ -114,6 +114,15 @@ export default defineConfig({
 });
 ```
 
+:::info
+For most recent projects, `vanillaExtractPlugin()` type is incompatible with `esbuildPlugins`.
+If the compiler is giving you an incompability error over the `Plugin` type, you can safely suppress
+it in most of the cases via `@ts-ignore`.
+
+For more info, see [this feature](https://github.com/evanw/esbuild/commit/01efc056ac5bd0eed987c9dd592b443e6974742c#diff-53664fbdfc62af3b722184289b51ff956243fc8f7e81fb9d0548219307587f7cR136)
+introduced in `esbuild` version [0.17.1](https://github.com/evanw/esbuild/releases/tag/v0.17.1)
+:::
+
 And a file named `jsxShim.ts` in your project root:
 
 ```ts


### PR DESCRIPTION
By starting up a new project, I noticed that `vanillaExtractPlugin` type is now incompatible with `tsup`'s `esbuildPlugins` as they [added a new type](https://github.com/evanw/esbuild/commit/01efc056ac5bd0eed987c9dd592b443e6974742c#diff-53664fbdfc62af3b722184289b51ff956243fc8f7e81fb9d0548219307587f7cR136) in the `esbuild` plugin's `BuildOptions.entryPoints` declaration to [support an array of objects](https://github.com/evanw/esbuild/issues/2828).

I'm proposing a disclaimer to safely ignore the error if raised.

# Test Plan
Run the website locally
![Screen Shot 2023-02-26 at 22 31 48](https://user-images.githubusercontent.com/16003164/221438540-b1d61bd7-ed38-41cd-9af6-06e7f00cd58d.png)
