### PR TITLE
Better SSR support

### DIFF
--- a/packages/bento-design-system/package.json
+++ b/packages/bento-design-system/package.json
@@ -75,6 +75,7 @@
     "@react-aria/radio": "3.4.0",
     "@react-aria/separator": "3.2.4",
     "@react-aria/slider": "3.2.2",
+    "@react-aria/ssr": "3.5.0",
     "@react-aria/switch": "3.2.4",
     "@react-aria/textfield": "3.7.2",
     "@react-aria/tooltip": "3.3.2",

--- a/packages/bento-design-system/src/BentoProvider.tsx
+++ b/packages/bento-design-system/src/BentoProvider.tsx
@@ -1,4 +1,4 @@
-import { Children, PartialBentoConfig } from ".";
+import { Children, PartialBentoConfig, SSRProvider } from ".";
 import { bentoSprinkles } from "./internal";
 import { ToastProvider } from "./Toast/ToastProvider";
 import { OverlayProvider } from "@react-aria/overlays";
@@ -38,6 +38,7 @@ type Props = {
   locale?: string;
   config?: PartialBentoConfig;
   sprinkles?: SprinklesFn;
+  ssr?: boolean;
 } & DefaultMessages;
 
 export function createBentoProvider(
@@ -50,11 +51,12 @@ export function createBentoProvider(
     defaultMessages,
     linkComponent,
     locale,
+    ssr = false,
     ...props
   }: Props) {
     const linkComponentFromContext = useContext(LinkComponentContext);
 
-    return (
+    const providers = (
       <I18nProvider locale={locale}>
         <OverlayProvider style={{ height: "100%" }}>
           <DefaultMessagesContext.Provider value={{ defaultMessages }}>
@@ -69,6 +71,8 @@ export function createBentoProvider(
         </OverlayProvider>
       </I18nProvider>
     );
+
+    return ssr ? <SSRProvider>{providers}</SSRProvider> : providers;
   };
 }
 

--- a/packages/bento-design-system/src/DateField/Calendar.tsx
+++ b/packages/bento-design-system/src/DateField/Calendar.tsx
@@ -6,7 +6,7 @@ import { RefObject, useRef } from "react";
 import { Box, Stack, Tiles } from "..";
 import { Label } from "../Typography/Label/Label";
 import { Children } from "../util/Children";
-import { createPortal } from "../util/createPortal";
+import { useCreatePortal } from "../util/useCreatePortal";
 import { CalendarHeader } from "./CalendarHeader";
 import { calendar, weekDay } from "./DateField.css";
 import { Day } from "./Day";
@@ -58,6 +58,7 @@ export function Calendar(props: Props) {
     weekday: "narrow",
   });
   const overlayRef = useRef(null);
+  const createPortal = useCreatePortal();
 
   const { days, weekdayLabels } = useMonth({
     year: props.activeDate.year,

--- a/packages/bento-design-system/src/Menu/NestedMenu.tsx
+++ b/packages/bento-design-system/src/Menu/NestedMenu.tsx
@@ -7,6 +7,7 @@ import { Box, Inset, MenuItemProps, Popover, ListProps, MenuTriggerState } from 
 import { useBentoConfig } from "../BentoConfigContext";
 import { menuRecipe } from "./Menu.css";
 import { MenuList } from "./MenuList";
+import { useIsSSR } from "@react-aria/ssr";
 
 type Props = {
   items: MenuItemProps[];
@@ -37,6 +38,7 @@ export function NestedMenu({
 }: Props) {
   const config = useBentoConfig().menu;
   const overlayRef = useRef(null);
+  const isSSR = useIsSSR();
 
   const { menuProps } = useMenuTrigger({}, state, triggerRef);
   const { overlayProps: positionProps } = useOverlayPosition({
@@ -48,7 +50,7 @@ export function NestedMenu({
     offset,
   });
 
-  return state.isOpen
+  return state.isOpen && !isSSR
     ? createPortal(
         <FocusScope restoreFocus>
           <Box

--- a/packages/bento-design-system/src/Modal/Modal.tsx
+++ b/packages/bento-design-system/src/Modal/Modal.tsx
@@ -17,7 +17,7 @@ import { modalRecipe, underlay, modalBody } from "./Modal.css";
 import { useKeyPressEvent } from "react-use";
 import { useDefaultMessages } from "../util/useDefaultMessages";
 import { IconButton } from "../IconButton/IconButton";
-import { createPortal } from "../util/createPortal";
+import { useCreatePortal } from "../util/useCreatePortal";
 import { match } from "ts-pattern";
 import { useBentoConfig } from "../BentoConfigContext";
 
@@ -48,6 +48,7 @@ export function CustomModal(props: CustomModalProps) {
   const config = useBentoConfig().modal;
   const ref = useRef<HTMLDivElement>(null);
   const { overlayProps, underlayProps } = useOverlay({ ...props, isOpen: true }, ref);
+  const createPortal = useCreatePortal();
 
   usePreventScroll();
 

--- a/packages/bento-design-system/src/SelectField/SelectField.tsx
+++ b/packages/bento-design-system/src/SelectField/SelectField.tsx
@@ -6,7 +6,7 @@ import Select, {
 } from "react-select";
 import { Body, Chip, ListSize, LocalizedString } from "..";
 import { useField } from "@react-aria/label";
-import { useEffect, useMemo } from "react";
+import { useEffect, useRef } from "react";
 import { FieldProps } from "../Field/FieldProps";
 import { Field } from "../Field/Field";
 import * as selectComponents from "./components";
@@ -98,13 +98,16 @@ export function SelectField<A>(props: Props<A>) {
     validationState,
   });
 
-  const menuPortalTarget = useMemo(() => document.createElement("div"), []);
+  const menuPortalTarget = useRef<HTMLDivElement>();
   useEffect(() => {
-    document.body.appendChild(menuPortalTarget);
+    if (!menuPortalTarget.current) {
+      menuPortalTarget.current = document.createElement("div");
+    }
+    document.body.appendChild(menuPortalTarget.current);
 
     return () => {
-      if (document.body.contains(menuPortalTarget)) {
-        document.body.removeChild(menuPortalTarget);
+      if (document.body.contains(menuPortalTarget.current!)) {
+        document.body.removeChild(menuPortalTarget.current!);
       }
     };
   }, [menuPortalTarget]);
@@ -165,7 +168,7 @@ export function SelectField<A>(props: Props<A>) {
               return 0;
             })}
           placeholder={placeholder}
-          menuPortalTarget={menuPortalTarget}
+          menuPortalTarget={menuPortalTarget.current}
           components={{
             ...selectComponents,
             MultiValue,

--- a/packages/bento-design-system/src/Tooltip/Tooltip.tsx
+++ b/packages/bento-design-system/src/Tooltip/Tooltip.tsx
@@ -12,7 +12,7 @@ import {
 import { useTooltipTriggerState } from "@react-stately/tooltip";
 import { useTooltipTrigger, useTooltip } from "@react-aria/tooltip";
 import { tooltip, arrow as arrowStyle } from "./Tooltip.css";
-import { createPortal } from "../util/createPortal";
+import { useCreatePortal } from "../util/useCreatePortal";
 import { useBentoConfig } from "../BentoConfigContext";
 import { TooltipPlacement } from "../Field/FieldProps";
 
@@ -35,6 +35,7 @@ type Props = {
 export function Tooltip(props: Props) {
   const config = useBentoConfig().tooltip;
   const arrowRef = useRef<HTMLElement | null>(null);
+  const createPortal = useCreatePortal();
 
   const commonMiddleware = [shift(), offset(8)];
   const arrowMiddleware = arrow({ element: arrowRef });

--- a/packages/bento-design-system/src/index.ts
+++ b/packages/bento-design-system/src/index.ts
@@ -119,3 +119,6 @@ export { useComponentsShowcase } from "./useComponentsShowcase";
 export type { ClassValue } from "clsx";
 
 export { Time } from "@internationalized/date";
+
+export { SSRProvider } from "@react-aria/ssr";
+export type { SSRProviderProps } from "@react-aria/ssr";

--- a/packages/bento-design-system/src/util/createPortal.ts
+++ b/packages/bento-design-system/src/util/createPortal.ts
@@ -1,7 +1,0 @@
-import { ReactPortal } from "react";
-import { createPortal as createReactPortal } from "react-dom";
-import { Children } from "./Children";
-
-export function createPortal(children: Children): ReactPortal {
-  return createReactPortal(children, document.body);
-}

--- a/packages/bento-design-system/src/util/useCreatePortal.ts
+++ b/packages/bento-design-system/src/util/useCreatePortal.ts
@@ -1,0 +1,9 @@
+import { ReactPortal } from "react";
+import { createPortal as createReactPortal } from "react-dom";
+import { Children } from "./Children";
+import { useIsSSR } from "@react-aria/ssr";
+
+export function useCreatePortal(): (children: Children) => ReactPortal | null {
+  const isSSR = useIsSSR();
+  return (children) => (isSSR ? null : createReactPortal(children, document.body));
+}

--- a/packages/website/docs/02-Getting Started/04-ssr.mdx
+++ b/packages/website/docs/02-Getting Started/04-ssr.mdx
@@ -1,0 +1,19 @@
+# Server-side rendering (SSR)
+
+Bento uses [react-aria](https://react-spectrum.adobe.com/react-aria/) internally.
+react-aria auto generates unique ids for some of Bento components.
+
+To ensure the ids are consistent between the client and server in a SSR environment, you need to pass the `ssr` option to `BentoProvider`.
+
+E.g.:
+
+```tsx
+<BentoProvider defaultMessages={defaultMessages} ssr>
+  <YourSsrApp />
+</BentoProvider>
+```
+
+This will wrap all components in react-aria's `SSRProvider`.
+More info about SSR in react-aria [here](https://react-spectrum.adobe.com/react-aria/ssr.html).
+
+Alternatively, Bento also exposes `SSRProvider` directly, in the rare in case in which you want to use it separately from `BentoProvider`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,7 @@ importers:
       '@react-aria/radio': 3.4.0
       '@react-aria/separator': 3.2.4
       '@react-aria/slider': 3.2.2
+      '@react-aria/ssr': 3.5.0
       '@react-aria/switch': 3.2.4
       '@react-aria/textfield': 3.7.2
       '@react-aria/tooltip': 3.3.2
@@ -147,6 +148,7 @@ importers:
       '@react-aria/radio': 3.4.0_react@18.2.0
       '@react-aria/separator': 3.2.4_react@18.2.0
       '@react-aria/slider': 3.2.2_react@18.2.0
+      '@react-aria/ssr': 3.5.0_react@18.2.0
       '@react-aria/switch': 3.2.4_react@18.2.0
       '@react-aria/textfield': 3.7.2_react@18.2.0
       '@react-aria/tooltip': 3.3.2_react@18.2.0
@@ -5561,7 +5563,7 @@ packages:
       '@internationalized/message': 3.0.9
       '@internationalized/number': 3.1.1
       '@internationalized/string': 3.0.0
-      '@react-aria/ssr': 3.3.0_react@18.2.0
+      '@react-aria/ssr': 3.5.0_react@18.2.0
       '@react-aria/utils': 3.14.0_react@18.2.0
       '@react-types/shared': 3.15.0_react@18.2.0
       react: 18.2.0
@@ -5663,7 +5665,7 @@ packages:
       '@react-aria/focus': 3.9.0_react@18.2.0
       '@react-aria/i18n': 3.6.1_react@18.2.0
       '@react-aria/interactions': 3.12.0_react@18.2.0
-      '@react-aria/ssr': 3.3.0_react@18.2.0
+      '@react-aria/ssr': 3.5.0_react@18.2.0
       '@react-aria/utils': 3.14.0_react@18.2.0
       '@react-aria/visually-hidden': 3.5.0_react@18.2.0
       '@react-stately/overlays': 3.4.2_react@18.2.0
@@ -5767,12 +5769,12 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@react-aria/ssr/3.3.0_react@18.2.0:
-    resolution: {integrity: sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==}
+  /@react-aria/ssr/3.5.0_react@18.2.0:
+    resolution: {integrity: sha512-h0MJdSWOd1qObLnJ8mprU31wI8tmKFJMuwT22MpWq6psisOOZaga6Ml4u6Ee6M6duWWISjXvqO4Sb/J0PBA+nQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || 18
     dependencies:
-      '@babel/runtime': 7.18.9
+      '@swc/helpers': 0.4.14
       react: 18.2.0
 
   /@react-aria/switch/3.2.4_react@18.2.0:
@@ -5838,7 +5840,7 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || 18
     dependencies:
       '@babel/runtime': 7.18.9
-      '@react-aria/ssr': 3.3.0_react@18.2.0
+      '@react-aria/ssr': 3.5.0_react@18.2.0
       '@react-stately/utils': 3.5.1_react@18.2.0
       '@react-types/shared': 3.15.0_react@18.2.0
       clsx: 1.2.1
@@ -8052,6 +8054,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@swc/helpers/0.4.14:
+    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
+    dependencies:
+      tslib: 2.4.0
+
   /@szmarczak/http-timer/1.1.2:
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}
     engines: {node: '>=6'}
@@ -8918,7 +8925,6 @@ packages:
       '@vanilla-extract/css': ^1.0.0
     dependencies:
       '@vanilla-extract/css': 1.7.2
-    dev: false
 
   /@vanilla-extract/sprinkles/1.4.1_@vanilla-extract+css@1.9.5:
     resolution: {integrity: sha512-aW6CfMMToX4a+baLuVxwcT0FSACjX3xrNt8wdi/3LLRlLAfhyue8OK7kJxhcYNZfydBeWTP59aRy8p5FUTIeew==}


### PR DESCRIPTION
To use Bento in an SSR environment, the consumer needs to wrap the app in `SSRProvider` from react-aria. However, react-aria is an implementation detail, and we don't document this anywhere.

This PR:
- re-exports `SSRProvider` from react-aria
- adds a `ssr` prop to `BentoProvider` to that the provider can be applied automatically (without even knowing about react-aria)
- adds some docs about this