### PR TITLE
Generate .d.cts files alongside .d.ts files.

### DIFF
--- a/packages/bento-design-system/package.json
+++ b/packages/bento-design-system/package.json
@@ -34,8 +34,9 @@
   "types": "lib/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsup --minify --clean",
+    "build": "tsup --minify --clean && pnpm patch-esm-ts",
     "prepublishOnly": "pnpm build",
+    "patch-esm-ts": "find ./lib -type f -name \"*.d.ts\" -exec sh -c 'cp \"$1\" \"${1%.d.ts}.d.cts\"' _ {} \\;",
     "prettier-check": "prettier --parser=typescript \"src/**/*.{ts,tsx}\" --check",
     "prettier-write": "prettier --parser=typescript \"src/**/*.{ts,tsx}\" --write",
     "eslint-check": "eslint \"src/**/*.{js,ts,tsx}\"",


### PR DESCRIPTION
This is a workaround for https://github.com/egoist/tsup/issues/579 and more generally for the problems highlighted in this thread https://twitter.com/atcb/status/1634653474041503744?s=61&t=nC5rArtZAYIRm7854OZMDw

Manually checked here using https://arethetypeswrong.github.io/

Here's the result after the current PR

<img width="1779" alt="image" src="https://user-images.githubusercontent.com/691940/225983929-c943fa5a-11e0-4a87-b9ed-4ec8ab5e534b.png">

Here's how it is currently

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/691940/225984112-22c7d1f5-72e2-4ca5-b5ce-9cd4271f4d8e.png">
