### PR TITLE
Remove usage of react-use

### DIFF
--- a/packages/bento-design-system/package.json
+++ b/packages/bento-design-system/package.json
@@ -117,7 +117,6 @@
     "react-is": "18.2.0",
     "react-select": "^5.4.0",
     "react-table": "^7.8.0",
-    "react-use": "^17.4.0",
     "recharts": "^2.1.16",
     "ts-pattern": "^3.3.5"
   },

--- a/packages/bento-design-system/src/Modal/Modal.tsx
+++ b/packages/bento-design-system/src/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import {
   ActionsProps,
   ButtonProps,
@@ -14,7 +14,6 @@ import { useOverlay, usePreventScroll, useModal } from "@react-aria/overlays";
 import { useDialog } from "@react-aria/dialog";
 import { FocusScope } from "@react-aria/focus";
 import { modalRecipe, underlay, modalBody } from "./Modal.css";
-import { useKeyPressEvent } from "react-use";
 import { useDefaultMessages } from "../util/useDefaultMessages";
 import { IconButton } from "../IconButton/IconButton";
 import { useCreatePortal } from "../util/useCreatePortal";
@@ -83,10 +82,11 @@ export function CustomModal(props: CustomModalProps) {
 export function Modal(props: Props) {
   const config = useBentoConfig().modal;
   // Trigger the primary action on 'Enter' if there is one
-  useKeyPressEvent(
-    (key) => key.code === "Enter",
-    () => props.primaryAction?.onPress()
-  );
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => e.code === "Enter" && props.primaryAction?.onPress();
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
 
   const { defaultMessages } = useDefaultMessages();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,6 @@ importers:
       react-is: 18.2.0
       react-select: ^5.4.0
       react-table: ^7.8.0
-      react-use: ^17.4.0
       recharts: ^2.1.16
       smooth-release: 8.0.9
       storybook-addon-themes: 6.1.0
@@ -181,7 +180,6 @@ importers:
       react-is: 18.2.0
       react-select: 5.4.0_zlkr355vuqapsh7ngap6ljrwsi
       react-table: 7.8.0_react@18.2.0
-      react-use: 17.4.0_biqbaboplfbrettd7655fr4n2y
       recharts: 2.1.16_v2m5e27vhdewzwhryxwfaorcca
       ts-pattern: 3.3.5
     devDependencies:


### PR DESCRIPTION
react-use is not actively maintained anymore, and we were only using a single hook from the library, so I've used an equivalent `useEffect` instead and removed the dependency altogether.