### PR TITLE
Upgrade sprinkles to 1.6.0

### DIFF
--- a/packages/bento-design-system/package.json
+++ b/packages/bento-design-system/package.json
@@ -108,7 +108,7 @@
     "@vanilla-extract/css": "1.7.2",
     "@vanilla-extract/dynamic": "2.0.3",
     "@vanilla-extract/recipes": "0.2.5",
-    "@vanilla-extract/sprinkles": "1.4.1",
+    "@vanilla-extract/sprinkles": "1.6.0",
     "clsx": "^1.2.1",
     "deepmerge-ts": "^4.3.0",
     "lodash.pick": "4.4.0",

--- a/packages/bento-design-system/src/sprinkles.ts
+++ b/packages/bento-design-system/src/sprinkles.ts
@@ -1,6 +1,5 @@
 import { createSprinkles, defineProperties } from "@vanilla-extract/sprinkles";
 import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
-import { SprinklesProperties } from "@vanilla-extract/sprinkles/dist/declarations/src/types";
 import {
   responsiveProperties as bentoResponsiveProperties,
   statusProperties as bentoStatusProperties,
@@ -8,6 +7,9 @@ import {
 } from "./util/atoms";
 import { breakpoints } from "./util/breakpoints";
 import { statusConditions } from "./util/conditions";
+
+type VarargParameters<T> = T extends (args: infer P) => any ? P : never;
+type SprinklesProperties = VarargParameters<typeof createSprinkles>;
 
 export function createDefineBentoSprinklesFn() {
   function defineBentoSprinkles<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
       '@vanilla-extract/esbuild-plugin': 2.1.0
       '@vanilla-extract/private': 1.0.3
       '@vanilla-extract/recipes': 0.2.5
-      '@vanilla-extract/sprinkles': 1.4.1
+      '@vanilla-extract/sprinkles': 1.6.0
       '@vanilla-extract/webpack-plugin': 2.1.12
       clsx: ^1.2.1
       css-loader: 6.7.3
@@ -171,7 +171,7 @@ importers:
       '@vanilla-extract/css': 1.7.2
       '@vanilla-extract/dynamic': 2.0.3
       '@vanilla-extract/recipes': 0.2.5_@vanilla-extract+css@1.7.2
-      '@vanilla-extract/sprinkles': 1.4.1_@vanilla-extract+css@1.7.2
+      '@vanilla-extract/sprinkles': 1.6.0_@vanilla-extract+css@1.7.2
       clsx: 1.2.1
       deepmerge-ts: 4.3.0
       lodash.pick: 4.4.0
@@ -179,14 +179,14 @@ importers:
       react-dropzone: 14.2.3_react@18.2.0
       react-input-mask: 2.0.4_biqbaboplfbrettd7655fr4n2y
       react-is: 18.2.0
-      react-select: 5.4.0_yna5zfkjq3tdsgjuxtqeszwipe
+      react-select: 5.4.0_zlkr355vuqapsh7ngap6ljrwsi
       react-table: 7.8.0_react@18.2.0
       recharts: 2.1.16_v2m5e27vhdewzwhryxwfaorcca
       ts-pattern: 3.3.5
     devDependencies:
-      '@babel/preset-env': 7.18.10_@babel+core@7.18.10
-      '@babel/preset-react': 7.18.6_@babel+core@7.18.10
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.18.10
+      '@babel/preset-env': 7.18.10_@babel+core@7.21.0
+      '@babel/preset-react': 7.18.6_@babel+core@7.21.0
+      '@babel/preset-typescript': 7.18.6_@babel+core@7.21.0
       '@react-types/breadcrumbs': 3.4.4_react@18.2.0
       '@react-types/button': 3.6.2_react@18.2.0
       '@react-types/datepicker': 3.1.2_react@18.2.0
@@ -230,7 +230,7 @@ importers:
       smooth-release: 8.0.9
       storybook-addon-themes: 6.1.0_bb2bxwco6ptpubzwpazr52qf6i
       style-loader: 3.3.2_webpack@5.76.3
-      ts-jest: 28.0.8_7xkm47xsxb3fpzmvjfhug2rn4q
+      ts-jest: 28.0.8_n5rr6fgzvmm4crk4i75bonkttq
       ts-loader: 9.3.1_pghhqdqs37z5wnqwtcp26nsz4e
       tsup: 6.6.3_g37ewoe4p726dtzi7cbcwoyllq
       typescript: 4.7.4
@@ -391,7 +391,7 @@ importers:
       '@types/babel__traverse': 7.18.5
       '@types/node': 18.16.4
       '@types/react': 18.0.15
-      '@vanilla-extract/sprinkles': 1.4.1_@vanilla-extract+css@1.7.2
+      '@vanilla-extract/sprinkles': 1.4.1_@vanilla-extract+css@1.9.5
       eslint-config-react-app: 7.0.1_qov3uxrlfsj6amljq2ujm4ue5a
       lint-staged: 13.0.3
       raw-loader: 4.0.2_webpack@5.76.3
@@ -2745,20 +2745,6 @@ packages:
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.21.0
       '@babel/types': 7.21.2
 
-  /@babel/plugin-transform-react-jsx/7.21.0_@babel+core@7.18.10:
-    resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.10
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.10
-      '@babel/types': 7.21.2
-    dev: true
-
   /@babel/plugin-transform-react-jsx/7.21.0_@babel+core@7.21.0:
     resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
     engines: {node: '>=6.9.0'}
@@ -4366,14 +4352,14 @@ packages:
       - uglify-js
       - webpack-cli
 
-  /@emotion/babel-plugin/11.9.2_@babel+core@7.18.10:
+  /@emotion/babel-plugin/11.9.2_@babel+core@7.21.0:
     resolution: {integrity: sha512-Pr/7HGH6H6yKgnVFNEj2MVlreu3ADqftqjqwUvDy/OJzKFgxKeTQ+eeUf20FOTuHVkDON2iNa25rAXVYtWJCjw==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.21.0
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.10
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.21.0
       '@babel/runtime': 7.18.9
       '@emotion/hash': 0.8.0
       '@emotion/memoize': 0.7.5
@@ -4447,7 +4433,7 @@ packages:
     resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
     dev: false
 
-  /@emotion/react/11.9.3_dekd3qhq25os2zmp2sxj6oaoou:
+  /@emotion/react/11.9.3_fwfczareegtkcpgyfvufixb4du:
     resolution: {integrity: sha512-g9Q1GcTOlzOEjqwuLF/Zd9LC+4FljjPjDfxSM7KmEakm+hsHXk+bYZ2q+/hTJzr0OUNkujo72pXLQvXj6H+GJQ==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -4459,9 +4445,9 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.21.0
       '@babel/runtime': 7.18.9
-      '@emotion/babel-plugin': 11.9.2_@babel+core@7.18.10
+      '@emotion/babel-plugin': 11.9.2_@babel+core@7.21.0
       '@emotion/cache': 11.9.3
       '@emotion/serialize': 1.0.4
       '@emotion/utils': 1.1.0
@@ -8796,9 +8782,26 @@ packages:
       '@vanilla-extract/css': ^1.0.0
     dependencies:
       '@vanilla-extract/css': 1.7.2
+    dev: false
 
-  /@vanilla-extract/sprinkles/1.5.1_@vanilla-extract+css@1.9.5:
-    resolution: {integrity: sha512-xPYpeEZEC1mhiPqWCBPGdIHkpFaaQIbaAfG9W2JyIW0byqTP7CoaxdYNMPjhZuoV5lkTI14SJg8Bt+fZqmV5yQ==}
+  /@vanilla-extract/sprinkles/1.4.1_@vanilla-extract+css@1.9.5:
+    resolution: {integrity: sha512-aW6CfMMToX4a+baLuVxwcT0FSACjX3xrNt8wdi/3LLRlLAfhyue8OK7kJxhcYNZfydBeWTP59aRy8p5FUTIeew==}
+    peerDependencies:
+      '@vanilla-extract/css': ^1.0.0
+    dependencies:
+      '@vanilla-extract/css': 1.9.5
+    dev: true
+
+  /@vanilla-extract/sprinkles/1.6.0_@vanilla-extract+css@1.7.2:
+    resolution: {integrity: sha512-TDc/bKyYmt6PDd7/39a5HXUa+4mBI9PO0uw0jmxFMqe9EzrFEVevyRsjJ9KGK09ACItvVUotz98LIJTeliCbpQ==}
+    peerDependencies:
+      '@vanilla-extract/css': ^1.0.0
+    dependencies:
+      '@vanilla-extract/css': 1.7.2
+    dev: false
+
+  /@vanilla-extract/sprinkles/1.6.0_@vanilla-extract+css@1.9.5:
+    resolution: {integrity: sha512-TDc/bKyYmt6PDd7/39a5HXUa+4mBI9PO0uw0jmxFMqe9EzrFEVevyRsjJ9KGK09ACItvVUotz98LIJTeliCbpQ==}
     peerDependencies:
       '@vanilla-extract/css': ^1.0.0
     dependencies:
@@ -13122,8 +13125,8 @@ packages:
       '@babel/plugin-transform-react-jsx': ^7.14.9
       eslint: ^8.1.0
     dependencies:
-      '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.18.10
-      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.18.10
+      '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.21.0
+      '@babel/plugin-transform-react-jsx': 7.21.0_@babel+core@7.21.0
       eslint: 8.20.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
@@ -18463,7 +18466,7 @@ packages:
       '@types/react-dom': 18.2.1
       '@vanilla-extract/css': 1.9.5
       '@vanilla-extract/css-utils': 0.1.3
-      '@vanilla-extract/sprinkles': 1.5.1_@vanilla-extract+css@1.9.5
+      '@vanilla-extract/sprinkles': 1.6.0_@vanilla-extract+css@1.9.5
       '@vanilla-extract/webpack-plugin': 2.1.12_webpack@5.76.3
       babel-loader: 9.1.2_4xnmuwebvb2aqltewj7ixrj3jy
       classnames: 2.3.2
@@ -18537,7 +18540,7 @@ packages:
       '@types/react-dom': 18.2.1
       '@vanilla-extract/css': 1.9.5
       '@vanilla-extract/css-utils': 0.1.3
-      '@vanilla-extract/sprinkles': 1.5.1_@vanilla-extract+css@1.9.5
+      '@vanilla-extract/sprinkles': 1.6.0_@vanilla-extract+css@1.9.5
       '@vanilla-extract/webpack-plugin': 2.1.12_webpack@5.76.3
       babel-loader: 9.1.2_4xnmuwebvb2aqltewj7ixrj3jy
       classnames: 2.3.2
@@ -19853,7 +19856,7 @@ packages:
       react: 18.2.0
     dev: true
 
-  /react-select/5.4.0_yna5zfkjq3tdsgjuxtqeszwipe:
+  /react-select/5.4.0_zlkr355vuqapsh7ngap6ljrwsi:
     resolution: {integrity: sha512-CjE9RFLUvChd5SdlfG4vqxZd55AZJRrLrHzkQyTYeHlpOztqcgnyftYAolJ0SGsBev6zAs6qFrjm6KU3eo2hzg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || 18
@@ -19861,7 +19864,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.6
       '@emotion/cache': 11.9.3
-      '@emotion/react': 11.9.3_dekd3qhq25os2zmp2sxj6oaoou
+      '@emotion/react': 11.9.3_fwfczareegtkcpgyfvufixb4du
       '@types/react-transition-group': 4.4.5
       memoize-one: 5.2.1
       prop-types: 15.8.1
@@ -22115,7 +22118,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/28.0.8_7xkm47xsxb3fpzmvjfhug2rn4q:
+  /ts-jest/28.0.8_n5rr6fgzvmm4crk4i75bonkttq:
     resolution: {integrity: sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -22136,7 +22139,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@babel/core': 7.18.10
+      '@babel/core': 7.21.0
       bs-logger: 0.2.6
       esbuild: 0.17.10
       fast-json-stable-stringify: 2.1.0


### PR DESCRIPTION
This is another attempt of upgrading sprinkles. Last time we hit a performance regression which led to downgrading it in #542.

The core issue used to be the derivation of `SprinklesProperties`, which caused tsc to spit out a `.d.ts` in minutes (instead of seconds).

I've tested this branch and I cannot see the issue anymore (not sure why actually :O)