### PR TITLE
Fix default hint icon size

### DIFF
--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -245,7 +245,7 @@ export const field: FieldConfig = {
   internalSpacing: 4,
   tip: {
     icon: IconQuestionCircle,
-    iconSize: 12,
+    iconSize: 16,
     placement: "right",
   },
 };


### PR DESCRIPTION
<img width="720" alt="image" src="https://github.com/buildo/bento-design-system/assets/925635/f1e7abe7-a38b-4f9b-a148-a38f5a3c42b4">
