### PR TITLE
[Navigation] Allow to configure Destination's borderRadius and activeVisualElement line width

### DIFF
--- a/packages/bento-design-system/src/Navigation/Config.ts
+++ b/packages/bento-design-system/src/Navigation/Config.ts
@@ -14,6 +14,7 @@ export type NavigationConfig = {
   internalSpacing: SizeConfig<BentoSprinkles["gap"]>;
   activeVisualElement: ActiveVisualElementConfig | JSX.Element;
   uppercaseLabel: boolean;
+  radius: SizeConfig<BentoSprinkles["borderRadius"]>;
 };
 
 type ActiveVisualElementConfig = {

--- a/packages/bento-design-system/src/Navigation/Config.ts
+++ b/packages/bento-design-system/src/Navigation/Config.ts
@@ -18,6 +18,7 @@ export type NavigationConfig = {
 };
 
 type ActiveVisualElementConfig = {
+  lineWidth: SizeConfig<number | "100%">;
   lineHeight: SizeConfig<number>;
   lineColor: BentoSprinkles["decoration"];
 };

--- a/packages/bento-design-system/src/Navigation/Navigation.tsx
+++ b/packages/bento-design-system/src/Navigation/Navigation.tsx
@@ -90,6 +90,7 @@ function Destination({
       disabled={disabled}
       paddingX={config.destinationPaddingX[size]}
       paddingY={config.destinationPaddingY[size]}
+      borderRadius={config.radius[size]}
     >
       <Columns space={config.internalSpacing[size]} alignY="center" align="center">
         {icon && (

--- a/packages/bento-design-system/src/Navigation/Navigation.tsx
+++ b/packages/bento-design-system/src/Navigation/Navigation.tsx
@@ -70,11 +70,15 @@ function Destination({
       <Box
         position="absolute"
         left={0}
+        right={0}
         bottom={0}
-        width="full"
         background="currentColor"
         color={config.activeVisualElement.lineColor}
-        style={{ height: config.activeVisualElement.lineHeight[size] }}
+        style={{
+          height: config.activeVisualElement.lineHeight[size],
+          width: config.activeVisualElement.lineWidth[size],
+          margin: "0 auto",
+        }}
       />
     );
 

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -418,6 +418,10 @@ export const navigation: NavigationConfig = {
     },
   },
   uppercaseLabel: false,
+  radius: {
+    medium: 16,
+    large: 16,
+  },
 };
 
 export const readOnlyField: ReadOnlyFieldConfig = {

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -416,6 +416,10 @@ export const navigation: NavigationConfig = {
       medium: 4,
       large: 4,
     },
+    lineWidth: {
+      medium: 16,
+      large: 16,
+    },
   },
   uppercaseLabel: false,
   radius: {


### PR DESCRIPTION
<img width="541" alt="image" src="https://github.com/buildo/bento-design-system/assets/925635/cd09eac1-9c63-4a77-8b1b-42d152efcb26">
