### PR TITLE
Patch sprinkles to export SprinklesProperties

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
         "react-dom": "18",
         "@types/react": "18"
       }
+    },
+    "patchedDependencies": {
+      "@vanilla-extract/sprinkles@1.6.0": "patches/@vanilla-extract__sprinkles@1.6.0.patch"
     }
   }
 }

--- a/packages/bento-design-system/src/sprinkles.ts
+++ b/packages/bento-design-system/src/sprinkles.ts
@@ -1,4 +1,4 @@
-import { createSprinkles, defineProperties } from "@vanilla-extract/sprinkles";
+import { createSprinkles, defineProperties, SprinklesProperties } from "@vanilla-extract/sprinkles";
 import { addFunctionSerializer } from "@vanilla-extract/css/functionSerializer";
 import {
   responsiveProperties as bentoResponsiveProperties,
@@ -7,9 +7,6 @@ import {
 } from "./util/atoms";
 import { breakpoints } from "./util/breakpoints";
 import { statusConditions } from "./util/conditions";
-
-type VarargParameters<T> = T extends (args: infer P) => any ? P : never;
-type SprinklesProperties = VarargParameters<typeof createSprinkles>;
 
 export function createDefineBentoSprinklesFn() {
   function defineBentoSprinkles<

--- a/patches/@vanilla-extract__sprinkles@1.6.0.patch
+++ b/patches/@vanilla-extract__sprinkles@1.6.0.patch
@@ -1,0 +1,10 @@
+diff --git a/dist/vanilla-extract-sprinkles.cjs.d.ts b/dist/vanilla-extract-sprinkles.cjs.d.ts
+index 62e38f5e20ed9036a1306d05caa1ed7d496b3e41..9d8449538a601b295c055f89e74bccfbb0fe741f 100644
+--- a/dist/vanilla-extract-sprinkles.cjs.d.ts
++++ b/dist/vanilla-extract-sprinkles.cjs.d.ts
+@@ -222,4 +222,4 @@ declare const createAtomicStyles: typeof defineProperties;
+ /** @deprecated - Use `createSprinkles` */
+ declare const createAtomsFn: typeof createSprinkles;
+ 
+-export { ConditionalValue, RequiredConditionalValue, ResponsiveArray, createAtomicStyles, createAtomsFn, createMapValueFn, createNormalizeValueFn, createSprinkles, defineProperties };
++export { ConditionalValue, RequiredConditionalValue, ResponsiveArray, SprinklesProperties, createAtomicStyles, createAtomsFn, createMapValueFn, createNormalizeValueFn, createSprinkles, defineProperties };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,11 @@ lockfileVersion: 5.4
 overrides:
   '@types/react': ^18
 
+patchedDependencies:
+  '@vanilla-extract/sprinkles@1.6.0':
+    hash: tudhbyyv4ny3z7rjvvzcz3ffue
+    path: patches/@vanilla-extract__sprinkles@1.6.0.patch
+
 importers:
 
   .:


### PR DESCRIPTION
This is a temporary workaround (which uses [`pnpm patch`](https://pnpm.io/cli/patch)) while we wait for https://github.com/vanilla-extract-css/vanilla-extract/pull/1117 to be approved.

The workaround we had before (inferring the type from `createSprinkles`) causes a spike in downstream compilations (that is, a library using `createDefineBentoSprinklesFn`).