### PR TITLE
Improve renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,22 @@
 {
-  "extends": ["config:base", "schedule:earlyMondays"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":automergeStableNonMajor",
+    ":automergeLinters",
+    ":automergeTesters",
+    ":automergeTypes",
+    ":combinePatchMinorReleases",
+    ":pinAllExceptPeerDependencies"
+  ],
   "labels": ["dependencies"],
+  "automerge": true,
   "packageRules": [
     {
       "matchPackagePatterns": ["@react-aria", "@react-types", "@react-stately"],
       "groupName": "react-aria monorepo"
-    }
+    },
+    {}
   ],
-  "prHourlyLimit": 0
+  "prHourlyLimit": 1
 }


### PR DESCRIPTION
Automatically upgrading dependencies is cool, but the current strategy is not ideal.
When I configured the upgrades to be weekly, I wanted to reduce the noise of dependency updates, but we ended up in a situation in which we have many concurrent open PRs that constantly need rebasing.
This is also very costly since each rebase triggers a full Chromatic run.

Reducing the number concurrent PRs could be an idea, but it wouldn't work with the weekly schedule, since a lot of dependencies would simply not be updated (Renovate would run once a week for a maximum of N dependencies, so many dependencies updates would simply stay behind).

The new strategy in this PR is:
- run Renovate whenever (we could limit it to "outside office hours" but I don't think it would be too bothersome given the limited amount of activity we have in general)
- limit the concurrent PRs to 1 per hour
- automerge all non-major upgrades as soon as the require checks pass (except for linters and testers, which we can always upgrade)

This should ideally result in dependencies PRs getting opened -> test passing -> automerge, at most once per hour, sidestepping the rebasing issues entirely.

In case some PRs don't get automerged, we can look into it and fix them on a case-by-case basis.