### PR TITLE
Include defaultFonts.ts in sideEffects

### DIFF
--- a/packages/bento-design-system/package.json
+++ b/packages/bento-design-system/package.json
@@ -10,7 +10,8 @@
   "sideEffects": [
     "global.css.ts",
     "reset.css.ts",
-    "defaultTheme.css.ts"
+    "defaultTheme.css.ts",
+    "defaultFonts.ts"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
Otherwise ESBuild would just drop its imports in the bundle. The purpose of importing defaultFonts is to include the .woff/.woff2 files of the font in the output, which is side-effecting so it should be marked as such.

This was working anyway because defaultFonts is also its own entrypoint so the files were included regardless.
That said, if in the future we were to remove the defaultFonts entrypoint, it would've resulted in the files not showing up in the output anymore.

For context, here's the warning from the build:

```
 WARN  ▲ [WARNING] Ignoring this import because "src/defaultFonts.ts" was marked as having no side effects [ignored-bare-import]       11:09:43

    src/defaultTheme.ts:2:7:
      2 │ import "./defaultFonts";
        ╵        ~~~~~~~~~~~~~~~~

  It was excluded from the "sideEffects" array in the enclosing "package.json" file:

    package.json:10:2:
      10 │   "sideEffects": [
```