### PR TITLE
Fix onChange arg in Storybook

### DIFF
--- a/packages/bento-design-system/.storybook/preview.tsx
+++ b/packages/bento-design-system/.storybook/preview.tsx
@@ -36,7 +36,7 @@ export const parameters = {
       { name: "dark", value: "#1A212B" },
     ],
   },
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: "^(?!onChange)on[A-Z].*" },
   controls: {
     matchers: {
       color: /(background|color)$/i,


### PR DESCRIPTION
Not sure when, but at some point the `onChange` global arg wasn't working anymore in Storybook because it got overridden by the default `argTypesRegex`