### PR TITLE
Fix chromatic pipeline

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,7 @@
     "test": {},
     "eslint-check": {},
     "chromatic": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["build"]
     },
     "playroom-start": {
       "dependsOn": ["@buildo/bento-design-system#build"],


### PR DESCRIPTION
Since we moved the Storybook inside the main project we need to depend on `build` instead of `^build`