### PR TITLE
Change renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
     ":combinePatchMinorReleases",
     ":pinAllExceptPeerDependencies"
   ],
+  "schedule": ["after 1am and before 10am on Monday"],
   "labels": ["dependencies"],
   "automerge": true,
   "packageRules": [
@@ -25,6 +26,5 @@
       "allowedVersions": "<=2"
     }
   ],
-  "prHourlyLimit": 1,
   "prConcurrentLimit": 2
 }


### PR DESCRIPTION
Running renovate at any time is a bit annoying since it forces many rebases on our PRs.
This PR changes the behavior to:

- run Renovate only on Monday between 1am and 10am
- remove the hourly limit (but keeping the concurrent limit to 2)

This should allow us to update lots of dependencies all together once a week, without disrupting regular operations.