### PR TITLE
Make sure we're passing aria props to InternalCheckbox

### DIFF
--- a/packages/bento-design-system/src/Checkbox/InternalCheckbox.tsx
+++ b/packages/bento-design-system/src/Checkbox/InternalCheckbox.tsx
@@ -57,7 +57,7 @@ type Props = {
 
 export function InternalCheckbox({ option, inputRef, inputProps }: Props) {
   const config = useBentoConfig().selectionControl.element;
-  const { fieldProps, labelProps } = useLabel(option);
+  const { fieldProps, labelProps } = useLabel({ ...option, ...inputProps });
   const { isFocusVisible, focusProps } = useFocusRing({ autoFocus: inputProps.autoFocus });
   return (
     <Box


### PR DESCRIPTION
Tested that we don't get warnings anymore