### PR TITLE
Add retrocompatible overload for createBentoProvider

### DIFF
--- a/packages/bento-design-system/src/BentoProvider.tsx
+++ b/packages/bento-design-system/src/BentoProvider.tsx
@@ -49,10 +49,31 @@ type Props = {
 } & DefaultMessages;
 
 export function createBentoProvider(
-  config: PartialBentoConfig = {},
+  config?: PartialBentoConfig,
+  sprinkles?: SprinklesFn
+): (props: Props) => JSX.Element;
+
+export function createBentoProvider(
+  config?: PartialBentoConfig,
   theme?: BentoTheme,
-  sprinkles: SprinklesFn = bentoSprinkles
+  sprinkles?: SprinklesFn
+): (props: Props) => JSX.Element;
+
+export function createBentoProvider(
+  config: PartialBentoConfig = {},
+  themeOrSprinkles?: BentoTheme | SprinklesFn,
+  sprinkles_?: SprinklesFn
 ) {
+  let sprinkles: SprinklesFn = bentoSprinkles;
+  let theme: BentoTheme | undefined = undefined;
+  if (typeof themeOrSprinkles === "function") {
+    sprinkles = themeOrSprinkles;
+  }
+  if (typeof themeOrSprinkles === "object") {
+    theme = themeOrSprinkles;
+    sprinkles = sprinkles_ ?? bentoSprinkles;
+  }
+
   function OptionalThemeWrapper(props: { children: Children; theme?: BentoTheme }) {
     if (!props.theme) return <>{props.children}</>;
     return <BentoThemeProvider theme={props.theme}>{props.children}</BentoThemeProvider>;

--- a/packages/bento-design-system/stories/index.tsx
+++ b/packages/bento-design-system/stories/index.tsx
@@ -19,7 +19,6 @@ export const BentoProvider = createBentoProvider(
       itemsPerPageOptions: [5, 10, 20, 50],
     },
   },
-  undefined,
   sprinkles
 );
 


### PR DESCRIPTION
This fixes a breaking change we accidentally introduced in #580.

After this PR it will again be possible to invoke `createBentoProvider` with `sprinkles` as second parameter