### PR TITLE
Bugfix: TextField discards type other than "text" or "password"

### DIFF
--- a/packages/bento-design-system/src/TextField/TextField.tsx
+++ b/packages/bento-design-system/src/TextField/TextField.tsx
@@ -49,7 +49,10 @@ export function TextField(props: Props) {
     ? props.hidePasswordLabel ?? defaultMessages.TextField.hidePasswordLabel
     : props.showPasswordLabel ?? defaultMessages.TextField.showPasswordLabel;
 
-  const type = props.type === "password" && !showPassword ? "password" : "text";
+  const type = match(props.type ?? "text")
+    .with("password", () => (showPassword ? "text" : "password"))
+    .with("text", "email", "url", () => props.type)
+    .exhaustive();
 
   const rightAccessory = match(props.type ?? "text")
     .with("password", () => (


### PR DESCRIPTION
We accidentally discarded other valid values for `type` due to a faulty "show password" logic.