### PR TITLE
Re-add export of type SelectOption

### DIFF
--- a/packages/bento-design-system/src/SelectField/BaseSelect.tsx
+++ b/packages/bento-design-system/src/SelectField/BaseSelect.tsx
@@ -134,3 +134,5 @@ export function BaseSelect<A>(props: Props<A>) {
     </BentoConfigProvider>
   );
 }
+
+export type { SelectOption };


### PR DESCRIPTION
The type `SelectOption` was previously defined in the `SelectField.tsx` file, and automatically exported from there. Now that it was moved to the `types.ts` file, it was not exported any more. This should fix the issue.