### PR TITLE
Change BaseTextInput width to full

### DIFF
--- a/packages/bento-design-system/src/TextField/BaseTextInput.tsx
+++ b/packages/bento-design-system/src/TextField/BaseTextInput.tsx
@@ -74,7 +74,7 @@ export function BaseTextInput(props: Props) {
         type={type}
         // NOTE(gabro): this is to please TS, since the inputProps type is very broad
         color={undefined}
-        width={undefined}
+        width="full"
         height={undefined}
         className={[
           inputRecipe({


### PR DESCRIPTION
`width={undefined}` in `BaseTextInput` made it so that it would overflow when inside a component with a width constraint. This PR makes it align with `BaseNumberInput`, which already has `width="full"`.