### PR TITLE
Add clearable prop to single-select SelectField

### DIFF
--- a/packages/bento-design-system/src/SelectField/BaseSelect.tsx
+++ b/packages/bento-design-system/src/SelectField/BaseSelect.tsx
@@ -55,6 +55,7 @@ export function BaseSelect<A>(props: Props<A>) {
     autoFocus,
     menuSize = dropdownConfig.defaultMenuSize,
     searchable,
+    clearable = true,
   } = props;
 
   return (
@@ -79,7 +80,11 @@ export function BaseSelect<A>(props: Props<A>) {
             onChange(multiValue.map((a) => a.value));
           } else {
             const singleValue = o as SingleValueT<SelectOption<A>>;
-            onChange(singleValue == null ? undefined : singleValue.value);
+            if (clearable) {
+              onChange(singleValue == null ? undefined : singleValue.value);
+            } else {
+              singleValue != null && onChange(singleValue.value);
+            }
           }
         }}
         onBlur={onBlur}

--- a/packages/bento-design-system/src/SelectField/types.ts
+++ b/packages/bento-design-system/src/SelectField/types.ts
@@ -11,6 +11,7 @@ export type SelectOption<A> = Omit<
 
 export type BaseSingleProps = {
   isMulti?: false;
+  clearable?: boolean;
 };
 
 export type BaseMultiProps = {
@@ -18,6 +19,7 @@ export type BaseMultiProps = {
   showMultiSelectBulkActions?: boolean;
   selectAllButtonLabel?: LocalizedString;
   clearAllButtonLabel?: LocalizedString;
+  clearable?: never;
 } & (
   | {
       multiSelectMode?: "summary";

--- a/packages/bento-design-system/stories/Components/SelectField.stories.tsx
+++ b/packages/bento-design-system/stories/Components/SelectField.stories.tsx
@@ -7,7 +7,9 @@ import {
   SelectField,
   BentoConfigProvider,
   SelectFieldProps,
+  SelectOption,
 } from "..";
+import { useState } from "react";
 
 const meta = {
   component: SelectField,
@@ -190,4 +192,24 @@ export const CustomListConfig = {
       </BentoConfigProvider>
     ),
   ],
+} satisfies Story;
+
+// NOTE(gabro): using a render function instead of just args, because the `value/onChange` trick we
+// use to make the story controlled doesn't play well with the implementation of `clearable`
+export const NotClearable = {
+  args: {
+    clearable: false,
+  },
+  render: (args) => {
+    const [value, onChange] = useState<number | undefined>(undefined);
+    return (
+      <SelectField
+        label={args.label}
+        clearable={args.clearable}
+        options={args.options as SelectOption<number>[]}
+        value={value}
+        onChange={onChange}
+      />
+    );
+  },
 } satisfies Story;


### PR DESCRIPTION
Closes #807

Now if `clearable={false}` is set, the use cannot deselect the selected option (it's still allowed to start without a selected option, though).

`clearable` defaults to `true` to avoid breaking changes.
