### PR TITLE
Add vertical dividers to Table columns

### DIFF
--- a/packages/bento-design-system/src/Table/Config.ts
+++ b/packages/bento-design-system/src/Table/Config.ts
@@ -37,4 +37,5 @@ export type TableConfig = {
     iconButtonCell: CellPaddingConfig | undefined;
   };
   boundaryPadding: BentoSprinkles["padding"];
+  dividers: boolean;
 };

--- a/packages/bento-design-system/src/Table/Config.ts
+++ b/packages/bento-design-system/src/Table/Config.ts
@@ -37,5 +37,5 @@ export type TableConfig = {
     iconButtonCell: CellPaddingConfig | undefined;
   };
   boundaryPadding: BentoSprinkles["padding"];
-  dividers: boolean;
+  columnDividers: boolean;
 };

--- a/packages/bento-design-system/src/Table/Table.css.ts
+++ b/packages/bento-design-system/src/Table/Table.css.ts
@@ -196,16 +196,11 @@ export const cellContainerRecipe = strictRecipe({
   },
 });
 
-export const sectionHeaderContainer = style([
-  {
-    zIndex: 1,
-  },
-  bentoSprinkles({
-    position: "sticky",
-    left: 0,
-    background: "backgroundPrimary",
-  }),
-]);
+export const sectionHeaderContainer = bentoSprinkles({
+  position: "sticky",
+  left: 0,
+  background: "backgroundPrimary",
+});
 
 export const sectionHeader = bentoSprinkles({
   display: "inline-block",

--- a/packages/bento-design-system/src/Table/Table.css.ts
+++ b/packages/bento-design-system/src/Table/Table.css.ts
@@ -14,25 +14,133 @@ export const lastLeftStickyColumn = bentoSprinkles({
   paddingRight: 8,
 });
 
-export const columnHeader = bentoSprinkles({
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "center",
-  boxShadow: "outlineDecorativeBottom",
-  height: "full",
-});
-
-export const columnFooter = style([
-  {
-    boxShadow: `inset 0px 1px 0px ${vars.outlineColor.outlineDecorative}`,
-  },
-  bentoSprinkles({
+export const columnHeader = strictRecipe({
+  base: bentoSprinkles({
     display: "flex",
     flexDirection: "column",
     justifyContent: "center",
     height: "full",
   }),
-]);
+  variants: {
+    withDividers: {
+      false: bentoSprinkles({
+        boxShadow: "outlineDecorativeBottom",
+      }),
+    },
+    first: {
+      true: {},
+    },
+    lastLeftSticky: {
+      true: {},
+    },
+  },
+  compoundVariants: [
+    {
+      variants: {
+        withDividers: true,
+        first: true,
+        lastLeftSticky: false,
+      },
+      style: bentoSprinkles({
+        boxShadow: "outlineDecorativeBottom",
+      }),
+    },
+    {
+      variants: {
+        withDividers: true,
+        first: true,
+        lastLeftSticky: true,
+      },
+      style: style({
+        boxShadow: `inset -1px -1px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+    {
+      variants: {
+        withDividers: true,
+        first: false,
+        lastLeftSticky: false,
+      },
+      style: style({
+        boxShadow: `inset 1px -1px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+    {
+      variants: {
+        withDividers: true,
+        first: false,
+        lastLeftSticky: true,
+      },
+      style: style({
+        boxShadow: `inset 1px -1px ${vars.outlineColor.outlineDecorative}, inset -1px -1px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+  ],
+});
+
+export const columnFooter = strictRecipe({
+  base: bentoSprinkles({
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    height: "full",
+  }),
+  variants: {
+    withDividers: {
+      false: style({
+        boxShadow: `inset 0px 1px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+    first: {
+      true: {},
+    },
+    lastLeftSticky: {
+      true: {},
+    },
+  },
+  compoundVariants: [
+    {
+      variants: {
+        withDividers: true,
+        first: true,
+        lastLeftSticky: false,
+      },
+      style: style({
+        boxShadow: `inset 0px 1px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+    {
+      variants: {
+        withDividers: true,
+        first: true,
+        lastLeftSticky: true,
+      },
+      style: style({
+        boxShadow: `inset -1px 1px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+    {
+      variants: {
+        withDividers: true,
+        first: false,
+        lastLeftSticky: false,
+      },
+      style: style({
+        boxShadow: `inset 1px 1px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+    {
+      variants: {
+        withDividers: true,
+        first: false,
+        lastLeftSticky: true,
+      },
+      style: style({
+        boxShadow: `inset 1px 1px ${vars.outlineColor.outlineDecorative}, inset -1px 1px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+  ],
+});
 
 export const sortIconContainer = style({
   filter: "opacity(80%)",
@@ -105,4 +213,47 @@ export const sectionHeader = bentoSprinkles({
   left: 0,
   paddingX: 24,
   paddingY: 4,
+});
+
+export const cellColumnDivider = strictRecipe({
+  base: style({
+    boxShadow: `inset 1px 0px 0px ${vars.outlineColor.outlineDecorative}`,
+  }),
+  variants: {
+    first: {
+      true: {},
+    },
+    lastLeftSticky: {
+      true: {},
+    },
+  },
+  compoundVariants: [
+    {
+      variants: {
+        first: true,
+        lastLeftSticky: true,
+      },
+      style: style({
+        boxShadow: `inset -1px 0px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+    {
+      variants: {
+        first: false,
+        lastLeftSticky: true,
+      },
+      style: style({
+        boxShadow: `inset 1px 0px ${vars.outlineColor.outlineDecorative}, inset -1px 0px ${vars.outlineColor.outlineDecorative}`,
+      }),
+    },
+    {
+      variants: {
+        first: true,
+        lastLeftSticky: false,
+      },
+      style: style({
+        boxShadow: "none",
+      }),
+    },
+  ],
 });

--- a/packages/bento-design-system/src/Table/Table.tsx
+++ b/packages/bento-design-system/src/Table/Table.tsx
@@ -708,6 +708,7 @@ function SectionHeader({
       <Box
         className={sectionHeaderContainer}
         style={{
+          zIndex: numberOfStickyColumns > 0 ? 1 : undefined,
           gridColumn: `1 / ${numberOfStickyColumns > 0 ? numberOfStickyColumns + 1 : -1}`,
         }}
       >

--- a/packages/bento-design-system/src/Table/Table.tsx
+++ b/packages/bento-design-system/src/Table/Table.tsx
@@ -111,7 +111,7 @@ type Props<
   height?: { custom: string | number };
   onRowPress?: (row: Row<RowType<C>>) => void;
   virtualizeRows?: boolean | { estimateRowHeight: (index: number) => number };
-  dividers?: boolean;
+  columnDividers?: boolean;
 } & SortingProps<C>;
 
 /**
@@ -152,7 +152,7 @@ export function Table<
   height,
   onRowPress,
   virtualizeRows: virtualizeRowsConfig,
-  dividers,
+  columnDividers,
 }: Props<C>) {
   const config = useBentoConfig().table;
   const customOrderByFn = useMemo(
@@ -370,7 +370,7 @@ export function Table<
     .map(({ gridWidth = "fit-content" }) => gridWidthStyle(gridWidth))
     .join(" ");
 
-  const withDividers = dividers ?? config.dividers;
+  const withDividers = columnDividers ?? config.columnDividers;
 
   function renderCells<D extends Record<string, unknown>>(
     cells: Array<Cell<D>>,

--- a/packages/bento-design-system/src/Table/Table.tsx
+++ b/packages/bento-design-system/src/Table/Table.tsx
@@ -30,6 +30,7 @@ import {
   vars,
 } from "..";
 import {
+  cellColumnDivider,
   cellContainerRecipe,
   columnFooter,
   columnHeader,
@@ -110,6 +111,7 @@ type Props<
   height?: { custom: string | number };
   onRowPress?: (row: Row<RowType<C>>) => void;
   virtualizeRows?: boolean | { estimateRowHeight: (index: number) => number };
+  dividers?: boolean;
 } & SortingProps<C>;
 
 /**
@@ -150,6 +152,7 @@ export function Table<
   height,
   onRowPress,
   virtualizeRows: virtualizeRowsConfig,
+  dividers,
 }: Props<C>) {
   const config = useBentoConfig().table;
   const customOrderByFn = useMemo(
@@ -367,6 +370,8 @@ export function Table<
     .map(({ gridWidth = "fit-content" }) => gridWidthStyle(gridWidth))
     .join(" ");
 
+  const withDividers = dividers ?? config.dividers;
+
   function renderCells<D extends Record<string, unknown>>(
     cells: Array<Cell<D>>,
     rowIndex: number,
@@ -381,6 +386,7 @@ export function Table<
         first={index === 0}
         last={(index + 1) % flatColumns.length === 0}
         interactiveRow={interactiveRow}
+        withDividers={withDividers}
       >
         {cell.render("Cell")}
       </CellContainer>
@@ -459,6 +465,7 @@ export function Table<
             }
             first={index === 0}
             last={index + 1 === flatColumns.length}
+            withDividers={withDividers}
           />
         ))
       )}
@@ -482,6 +489,7 @@ export function Table<
             sticky={stickyLeftColumnsIds.includes(header.id)}
             first={index === 0}
             last={index + 1 === flatColumns.length}
+            withDividers={withDividers}
           />
         ))}
     </Box>
@@ -523,6 +531,7 @@ function ColumnHeader<D extends Record<string, unknown>>({
   sticky,
   first,
   last,
+  withDividers,
 }: {
   column: ColumnInstance<D> | HeaderGroup<D>;
   style: CSSProperties;
@@ -531,6 +540,7 @@ function ColumnHeader<D extends Record<string, unknown>>({
   sticky: boolean;
   first: boolean;
   last: boolean;
+  withDividers: boolean;
 }) {
   const config = useBentoConfig().table;
 
@@ -584,7 +594,7 @@ function ColumnHeader<D extends Record<string, unknown>>({
       }}
     >
       <Box
-        className={columnHeader}
+        className={[columnHeader({ withDividers, first, lastLeftSticky })]}
         background={config.headerBackgroundColor}
         color={config.headerForegroundColor}
         {...column.getHeaderProps(column.getSortByToggleProps())}
@@ -626,6 +636,7 @@ function ColumnFooter<D extends Record<string, unknown>>({
   sticky,
   first,
   last,
+  withDividers,
 }: {
   column: ColumnInstance<D> | HeaderGroup<D>;
   style: CSSProperties;
@@ -634,6 +645,7 @@ function ColumnFooter<D extends Record<string, unknown>>({
   sticky: boolean;
   first: boolean;
   last: boolean;
+  withDividers: boolean;
 }) {
   const config = useBentoConfig().table;
 
@@ -646,7 +658,7 @@ function ColumnFooter<D extends Record<string, unknown>>({
       }}
     >
       <Box
-        className={columnFooter}
+        className={columnFooter({ withDividers, first, lastLeftSticky })}
         background={config.footerBackgroundColor}
         color={config.footerForegroundColor}
         {...column.getFooterProps()}
@@ -723,6 +735,7 @@ function CellContainer({
   first,
   last,
   interactiveRow,
+  withDividers,
   ...props
 }: {
   children: any;
@@ -732,6 +745,7 @@ function CellContainer({
   first: boolean;
   last: boolean;
   interactiveRow: boolean;
+  withDividers: boolean;
 } & TableCellProps) {
   const tableConfig = useBentoConfig().table;
 
@@ -739,7 +753,10 @@ function CellContainer({
     <Box className={lastLeftSticky && lastLeftStickyColumn} style={style}>
       <Box
         background={index % 2 === 0 ? tableConfig.evenRowsBackgroundColor : "backgroundPrimary"}
-        className={cellContainerRecipe({ interactiveRow })}
+        className={[
+          cellContainerRecipe({ interactiveRow }),
+          withDividers && cellColumnDivider({ first, lastLeftSticky }),
+        ]}
         paddingLeft={first ? tableConfig.boundaryPadding : undefined}
         paddingRight={last ? tableConfig.boundaryPadding : undefined}
         {...props}
@@ -758,7 +775,11 @@ export type {
   Row as TableRow,
 } from "react-table";
 
-export type { Column as SimpleColumnType, Row as RowType } from "./types";
+export type {
+  Column as SimpleColumnType,
+  GroupedColumn as GroupedColumnType,
+  Row as RowType,
+} from "./types";
 
 export type { ColumnOptionsBase } from "./tableColumn";
 export type { Props as TableProps };

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -527,6 +527,7 @@ export const table: TableConfig = {
     iconButtonCell: { paddingX: 16, paddingY: 16 },
   },
   boundaryPadding: 8,
+  dividers: false,
 };
 
 export const toast: ToastConfig = {

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -527,7 +527,7 @@ export const table: TableConfig = {
     iconButtonCell: { paddingX: 16, paddingY: 16 },
   },
   boundaryPadding: 8,
-  dividers: false,
+  columnDividers: false,
 };
 
 export const toast: ToastConfig = {

--- a/packages/bento-design-system/stories/Components/Table.stories.tsx
+++ b/packages/bento-design-system/stories/Components/Table.stories.tsx
@@ -460,7 +460,7 @@ export const SimpleWithDividers = {
   args: {
     columns: exampleColumnsWithFooter,
     initialSorting: [{ id: "name" }],
-    dividers: true,
+    columnDividers: true,
   },
 } satisfies Story;
 
@@ -648,7 +648,7 @@ export const GroupedHeadersWithDividers = {
   args: {
     columns: exampleGroupedColumns,
     stickyHeaders: true,
-    dividers: true,
+    columnDividers: true,
     height: { custom: 320 },
   },
 } satisfies Story;

--- a/packages/bento-design-system/stories/Components/Table.stories.tsx
+++ b/packages/bento-design-system/stories/Components/Table.stories.tsx
@@ -78,6 +78,75 @@ const exampleColumns = [
   }),
 ] as const;
 
+const exampleColumnsWithFooter = [
+  tableColumn.button({
+    headerLabel: "Button",
+    accessor: "button",
+    sticky: "left",
+    disableSortBy: true,
+    align: "center",
+  }),
+  tableColumn.text({
+    headerLabel: "Name",
+    accessor: "name",
+    footer: "-",
+  }),
+  tableColumn.text({
+    headerLabel: "Extended address",
+    accessor: "address",
+    width: { custom: 200 },
+    footer: "-",
+  }),
+  tableColumn.textWithIcon({
+    headerLabel: "Country",
+    accessor: "country",
+    iconPosition: "right",
+    hint: "This is a hint",
+    footer: "-",
+  }),
+  tableColumn.number({
+    headerLabel: "Applications",
+    accessor: "applications",
+    valueFormatter: (value) => Intl.NumberFormat("en").format(value),
+    align: "right",
+    hint: { onPress: action("hint") },
+    footer: ({ rows }) =>
+      Intl.NumberFormat("en").format(
+        rows.reduce((acc, row) => acc + (row.values.applications ?? 0), 0)
+      ),
+  }),
+  tableColumn.numberWithIcon({
+    headerLabel: "Value",
+    accessor: "value",
+    valueFormatter: (value) => Intl.NumberFormat("en").format(value),
+    align: "right",
+  }),
+  tableColumn.label({
+    headerLabel: "Type",
+    accessor: "type",
+  }),
+  tableColumn.link({
+    headerLabel: "Website",
+    accessor: "website",
+    footer: "-",
+  }),
+  tableColumn.icon({
+    headerLabel: "Alerts",
+    accessor: "alerts",
+  }),
+  tableColumn.chip({
+    headerLabel: "Status",
+    accessor: "status",
+    align: "center",
+  }),
+  tableColumn.iconButton({
+    headerLabel: "Actions",
+    accessor: "deleteAction",
+    align: "center",
+    disableSortBy: true,
+  }),
+] as const;
+
 const exampleGroupedColumns = [
   {
     Header: "Group 1",
@@ -94,17 +163,20 @@ const exampleGroupedColumns = [
       tableColumn.text({
         headerLabel: "Name",
         accessor: "name",
+        footer: "-",
       }),
       tableColumn.text({
         headerLabel: "Extended address",
         accessor: "address",
         width: { custom: 200 },
+        footer: "-",
       }),
       tableColumn.textWithIcon({
         headerLabel: "Country",
         accessor: "country",
         iconPosition: "right",
         hint: "This is a hint",
+        footer: "-",
       }),
     ],
   },
@@ -117,6 +189,10 @@ const exampleGroupedColumns = [
         valueFormatter: (value) => Intl.NumberFormat("en").format(value),
         align: "right",
         hint: { onPress: action("hint") },
+        footer: ({ rows }) =>
+          Intl.NumberFormat("en").format(
+            rows.reduce((acc, row) => acc + (row.values.applications ?? 0), 0)
+          ),
       }),
       tableColumn.numberWithIcon({
         headerLabel: "Value",
@@ -380,6 +456,14 @@ export const Simple = {
   },
 } satisfies Story;
 
+export const SimpleWithDividers = {
+  args: {
+    columns: exampleColumnsWithFooter,
+    initialSorting: [{ id: "name" }],
+    dividers: true,
+  },
+} satisfies Story;
+
 export const Empty = {
   args: {
     data: [],
@@ -556,6 +640,15 @@ export const GroupedHeaders = {
   args: {
     columns: exampleGroupedColumns,
     stickyHeaders: true,
+    height: { custom: 320 },
+  },
+} satisfies Story;
+
+export const GroupedHeadersWithDividers = {
+  args: {
+    columns: exampleGroupedColumns,
+    stickyHeaders: true,
+    dividers: true,
     height: { custom: 320 },
   },
 } satisfies Story;


### PR DESCRIPTION
Closes SCOST-1039

This PR also fixes a bug on the handling of z-index for `SectionHeader` which resulted in this outcome if headers are sticky and there are no sticky column on the left:

<img width="1295" alt="Screenshot 2024-01-12 at 15 26 30" src="https://github.com/buildo/bento-design-system/assets/26444095/44c32322-ae43-4881-bc78-78246d5b558d">

