### PR TITLE
Change style of sticky columns padding when using dividers

### DIFF
--- a/packages/bento-design-system/src/Table/Table.css.ts
+++ b/packages/bento-design-system/src/Table/Table.css.ts
@@ -9,9 +9,23 @@ export const table = style({
   isolation: "isolate",
 });
 
-export const lastLeftStickyColumn = bentoSprinkles({
-  background: "backgroundPrimary",
-  paddingRight: 8,
+export const lastLeftStickyColumn = strictRecipe({
+  variants: {
+    withDividers: {
+      true: style([
+        {
+          paddingRight: 2,
+        },
+        bentoSprinkles({
+          background: "outlineDecorative",
+        }),
+      ]),
+      false: bentoSprinkles({
+        background: "backgroundPrimary",
+        paddingRight: 8,
+      }),
+    },
+  },
 });
 
 export const columnHeader = strictRecipe({

--- a/packages/bento-design-system/src/Table/Table.tsx
+++ b/packages/bento-design-system/src/Table/Table.tsx
@@ -585,7 +585,10 @@ function ColumnHeader<D extends Record<string, unknown>>({
 
   return (
     <Box
-      className={[lastLeftSticky && lastLeftStickyColumn, stickyHeaders && stickyColumnHeader]}
+      className={[
+        lastLeftSticky && lastLeftStickyColumn({ withDividers }),
+        stickyHeaders && stickyColumnHeader,
+      ]}
       style={{
         ...style,
         gridColumnEnd: column.columns ? `span ${column.columns.length}` : undefined,
@@ -650,7 +653,10 @@ function ColumnFooter<D extends Record<string, unknown>>({
 
   return (
     <Box
-      className={[lastLeftSticky && lastLeftStickyColumn, stickyFooters && stickyColumnFooter]}
+      className={[
+        lastLeftSticky && lastLeftStickyColumn({ withDividers }),
+        stickyFooters && stickyColumnFooter,
+      ]}
       style={{
         ...style,
         zIndex: sticky ? zIndexes.leftStickyHeader : zIndexes.header,
@@ -750,7 +756,7 @@ function CellContainer({
   const tableConfig = useBentoConfig().table;
 
   return (
-    <Box className={lastLeftSticky && lastLeftStickyColumn} style={style}>
+    <Box className={lastLeftSticky && lastLeftStickyColumn({ withDividers })} style={style}>
       <Box
         background={index % 2 === 0 ? tableConfig.evenRowsBackgroundColor : "backgroundPrimary"}
         className={[


### PR DESCRIPTION
When using a table with dividers, changed padding after sticky columns to be 2px wide and have for background the same color as the dividers.

![Screenshot 2024-02-21 at 15 48 43](https://github.com/buildo/bento-design-system/assets/26444095/97a7c38f-a193-477f-baca-8c81b4b801d2)
