### PR TITLE
Fix icon X's size in FileUploaderField to 16

### DIFF
--- a/packages/bento-design-system/src/FileUploaderField/FileUploaderField.tsx
+++ b/packages/bento-design-system/src/FileUploaderField/FileUploaderField.tsx
@@ -315,7 +315,7 @@ export function FileUploaderField<E extends string>({
                   <IconButton
                     kind="transparent"
                     hierarchy="secondary"
-                    size={12}
+                    size={16}
                     label={unsafeLocalizedString("remove")}
                     icon={IconX}
                     onPress={() => onChange(undefined)}


### PR DESCRIPTION
Updates the size of the `IconButton` component within the `FileUploaderField` from 12 to 16.
- Changes the `size` property of the `IconButton` component from 12 to 16 to match the task requirement.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/buildo/bento-design-system?shareId=9858516a-ab4c-4700-8c8f-1774f2796036).