### PR TITLE
Execute scripts during publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           token: ${{ secrets.NPM_TOKEN }}
           access: "public"
           provenance: true
+          ignore-scripts: false
 
       - name: Publish to Github
         uses: JS-DevTools/npm-publish@v3
@@ -60,6 +61,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           access: "public"
           provenance: true
+          ignore-scripts: false
 
       - uses: slackapi/slack-github-action@v1.24.0
         if: ${{ job.status == 'success' }}


### PR DESCRIPTION
This should fix #883.
The GitHub Action we started using for publishing does not run prepublish scripts by default, so we ended up publishing without running `build` first.