### PR TITLE
[Columns] Fix check for child as lazy node Column

### DIFF
--- a/packages/bento-design-system/src/Layout/Columns.tsx
+++ b/packages/bento-design-system/src/Layout/Columns.tsx
@@ -1,4 +1,5 @@
 import { ReactChild, ReactElement } from "react";
+import { isLazy } from "react-is";
 import { flattenChildren } from "../util/flattenChildren";
 import { BoxProps, Box } from "../Box/Box";
 import { ResponsiveSpace } from "../internal";
@@ -66,5 +67,14 @@ export function Columns({ space, children, align, alignY, collapseBelow, reverse
 }
 
 function isColumn(child: ReactChild): child is ReactElement<ColumnProps> {
-  return typeof child === "object" && "type" in child && child.type === Column;
+  if (typeof child !== "object" || !("type" in child)) {
+    return false;
+  }
+
+  // Check if it is a lazy node (RSC)
+  if (isLazy(child.type)) {
+    return !!(child.type as any)._payload?.value?.includes("Column");
+  }
+
+  return child.type === Column;
 }


### PR DESCRIPTION
Closes #835

Fix based on [this comment](https://github.com/buildo/bento-design-system/issues/835#issuecomment-2291839752). As the check now uses internals from a canary version of React any future updates to the payload format could break the check.