### PR TITLE
Enable autoResetSortBy when manual sorting and initialSorting are used together

### DIFF
--- a/packages/bento-design-system/src/Table/Table.tsx
+++ b/packages/bento-design-system/src/Table/Table.tsx
@@ -184,6 +184,8 @@ export function Table<
     [columns]
   );
 
+  const hasOnSort = !!onSort;
+
   const {
     getTableProps,
     headerGroups,
@@ -200,8 +202,8 @@ export function Table<
         hiddenColumns: groupBy ? [groupBy] : [],
       },
       orderByFn: customOrderByFn,
-      manualSortBy: Boolean(onSort),
-      autoResetSortBy: false,
+      manualSortBy: hasOnSort,
+      autoResetSortBy: !hasOnSort && !!initialSorting,
     },
     useGridLayout,
     useGroupBy,


### PR DESCRIPTION
This PR enables `autoResetSortBy` when both `onSort` (_manual sorting_) and `initialSorting` are set, so that we can gain more control on the table's `sortBy` internal state (it resets to the initial state whenever `data` changes). This is useful when the `data` sorting can be updated from outside the table, like for example controls (maybe a "reset table" button) or route navigation.