### PR TITLE
fix(NumberField, NumberInput): send field name on form submit

### DIFF
--- a/packages/bento-design-system/src/NumberField/BaseNumberInput.tsx
+++ b/packages/bento-design-system/src/NumberField/BaseNumberInput.tsx
@@ -12,8 +12,10 @@ import { getRadiusPropsFromConfig } from "../util/BorderRadiusConfig";
 type Props = BaseNumberProps & {
   inputProps: React.InputHTMLAttributes<HTMLInputElement>;
   inputRef: React.Ref<HTMLInputElement>;
+  numberValue: number;
   validationState: "valid" | "invalid";
   disabled?: boolean;
+  name?: string;
 } & FormatProps;
 
 export function BaseNumberInput(props: Props) {
@@ -116,6 +118,13 @@ export function BaseNumberInput(props: Props) {
         <Box display="flex" justifyContent="center" alignItems="center">
           {rightAccessory}
         </Box>
+      )}
+      {props.name && (
+        <input
+          type="hidden"
+          name={props.name}
+          value={isNaN(props.numberValue) ? "" : props.numberValue}
+        />
       )}
     </Box>
   );

--- a/packages/bento-design-system/src/NumberField/NumberField.tsx
+++ b/packages/bento-design-system/src/NumberField/NumberField.tsx
@@ -47,6 +47,8 @@ export function NumberField(props: Props) {
         inputProps={inputProps}
         inputRef={inputRef}
         validationState={validationState}
+        name={props.name}
+        numberValue={state.numberValue}
         {...props}
       />
     </Field>

--- a/packages/bento-design-system/src/NumberField/NumberInput.tsx
+++ b/packages/bento-design-system/src/NumberField/NumberInput.tsx
@@ -14,7 +14,7 @@ type Props = AtLeast<Pick<HTMLAttributes<HTMLInputElement>, "aria-label" | "aria
     "autoFocus" | "disabled" | "name" | "onBlur" | "onChange" | "value"
   > &
   BaseNumberProps & {
-    validationState: "valid" | "invalid";
+    validationState?: "valid" | "invalid";
   } & FormatProps &
   Pick<NumberFieldStateOptions, "minValue" | "maxValue" | "step" | "formatOptions">;
 
@@ -35,7 +35,16 @@ export function NumberInput(props: Props) {
     inputRef
   );
 
-  return <BaseNumberInput inputProps={inputProps} inputRef={inputRef} {...props} />;
+  return (
+    <BaseNumberInput
+      inputProps={inputProps}
+      inputRef={inputRef}
+      name={props.name}
+      numberValue={state.numberValue}
+      validationState={props.validationState ?? "valid"}
+      {...props}
+    />
+  );
 }
 
 export type { Props as NumberInputProps };

--- a/packages/bento-design-system/stories/Components/Inputs/NumberInput.stories.tsx
+++ b/packages/bento-design-system/stories/Components/Inputs/NumberInput.stories.tsx
@@ -5,8 +5,8 @@ const meta = {
   component: NumberInput,
   args: {
     value: undefined,
+    name: "number-input",
     "aria-label": "number-input",
-    validationState: "valid",
   },
 } satisfies Meta<typeof NumberInput>;
 

--- a/packages/configuration-builder/src/ColorEditor/CounterField.tsx
+++ b/packages/configuration-builder/src/ColorEditor/CounterField.tsx
@@ -65,6 +65,8 @@ export function CounterField(props: Omit<NumberFieldProps, "kind" | "currency">)
           inputProps={inputProps}
           inputRef={inputRef}
           validationState={validationState}
+          name={props.name}
+          numberValue={state.numberValue}
           {...props}
         />
         <Column width="content">


### PR DESCRIPTION
As per [react-spectrum implementation](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-spectrum/numberfield/src/NumberField.tsx#L192).

React-aria doesn't include the name in the `inputProps`. Their reasoning is that you should never send the number formatted in the user's locale to the server. They suggest including an additional hidden input that sends the numeric value instead.