### PR TITLE
fix NumberInput background

### DIFF
--- a/packages/bento-design-system/src/NumberField/BaseNumberInput.tsx
+++ b/packages/bento-design-system/src/NumberField/BaseNumberInput.tsx
@@ -89,7 +89,10 @@ export function BaseNumberInput(props: Props) {
       paddingY={config.paddingY}
       gap={config.internalSpacing}
       disabled={props.disabled}
+      background={config.background.default}
       {...getRadiusPropsFromConfig(config.radius)}
+      style={getReadOnlyBackgroundStyle(config)}
+      readOnly={props.isReadOnly}
     >
       <Box
         as="input"
@@ -109,10 +112,8 @@ export function BaseNumberInput(props: Props) {
             ellipsis: false,
           }),
         ]}
-        background={config.background.default}
         outline="none"
         flexGrow={1}
-        style={getReadOnlyBackgroundStyle(config)}
       />
       {rightAccessory && (
         <Box display="flex" justifyContent="center" alignItems="center">


### PR DESCRIPTION
Closes #1022 

Apply the background to the whole field, instead of just the internal input:

<img width="360" alt="image" src="https://github.com/user-attachments/assets/04f8100a-481e-4d43-80ec-c0abeb95493e" />
