### PR TITLE
fix(donut-chart): show item color in tooltip

### DIFF
--- a/packages/bento-design-system/src/Charts/Tooltip/Tooltip.tsx
+++ b/packages/bento-design-system/src/Charts/Tooltip/Tooltip.tsx
@@ -47,6 +47,7 @@ export const useTooltip = <TValue extends ValueType, TName extends NameType>(
                 : typeof formatterResult === "string" || typeof formatterResult === "number"
                 ? `${name}: ${formatterResult}`
                 : `${name}: ${value}`;
+              const tooltipColor = color ?? item.fill;
               return (
                 <Columns key={name} space={4} alignY="center">
                   <Column width="content">
@@ -54,7 +55,7 @@ export const useTooltip = <TValue extends ValueType, TName extends NameType>(
                       height={16}
                       width={16}
                       borderRadius={4}
-                      style={{ backgroundColor: color }}
+                      style={{ backgroundColor: tooltipColor }}
                     />
                   </Column>
                   <Body size="small">{formattedText}</Body>


### PR DESCRIPTION
The tooltip color was based on the series color, but in the case of a DonutChart we have just one series (with no defined color), while the color is actually determined by each individual item within the series.
With this fix, I'm fallbacking to the item color if the series color is undefined. Not sure if the item color should always win over the series color though.

<img width="528" height="291" alt="image" src="https://github.com/user-attachments/assets/0ace6361-6473-493a-8c74-7258194cc89c" />
