### PR TITLE
feat: add configurable multi-select search persistence

### DIFF
--- a/packages/bento-design-system/src/SelectField/BaseSelect.tsx
+++ b/packages/bento-design-system/src/SelectField/BaseSelect.tsx
@@ -5,7 +5,7 @@ import { FieldProps } from "../Field/FieldProps";
 import { BentoConfigProvider, useBentoConfig } from "../BentoConfigContext";
 import { AriaLabelingProps, DOMProps } from "@react-types/shared";
 import * as selectComponents from "./components";
-import { ComponentProps, useEffect, useId, useRef } from "react";
+import { ComponentProps, useEffect, useId, useRef, useState } from "react";
 import { BaseMultiProps, BaseSelectProps, BaseSingleProps, SelectOption } from "./types";
 
 type MultiProps<A> = BaseMultiProps &
@@ -63,6 +63,13 @@ export function BaseSelect<A>(props: Props<A>) {
     loadingMessage,
     loadOptions,
   } = props;
+
+  const [inputValue, setInputValue] = useState("");
+  const preserveMultiSelectSearch =
+    isMulti &&
+    !isReadOnly &&
+    (searchable ?? true) &&
+    (props.multiSelectSearchMode ?? dropdownConfig.multiSelectSearchMode) === "preserve-on-select";
 
   // NOTE(gabro): we want to make sure we have a stable ID across SSR rendering, to overcome this issue with react-select https://github.com/JedWatson/react-select/issues/2629
   const generatedId = useId();
@@ -143,6 +150,18 @@ export function BaseSelect<A>(props: Props<A>) {
       ? props.selectAllButtonLabel ?? defaultMessages.SelectField.selectAllButtonLabel
       : undefined,
     multiSelectMode: isMulti ? props.multiSelectMode : undefined,
+    ...(preserveMultiSelectSearch
+      ? {
+          inputValue,
+          onInputChange: (newValue, actionMeta) => {
+            const nextInputValue =
+              actionMeta.action === "set-value" ? actionMeta.prevInputValue : newValue;
+            setInputValue(nextInputValue);
+            return nextInputValue;
+          },
+          blurInputOnSelect: false,
+        }
+      : {}),
   };
 
   return (
@@ -151,6 +170,7 @@ export function BaseSelect<A>(props: Props<A>) {
       {loadOptions ? (
         <AsyncSelect
           {...commonProps}
+          cacheOptions={preserveMultiSelectSearch}
           defaultOptions={previousOptions.current.filter((o) =>
             (isMulti ? value : [value]).includes(o.value)
           )}

--- a/packages/bento-design-system/src/SelectField/Config.ts
+++ b/packages/bento-design-system/src/SelectField/Config.ts
@@ -5,6 +5,8 @@ import { ListConfig } from "../List/Config";
 import { BorderRadiusConfig } from "../util/BorderRadiusConfig";
 import { Children } from "../util/Children";
 
+export type MultiSelectSearchMode = "clear-on-select" | "preserve-on-select";
+
 export type DropdownConfig = {
   elevation: "small" | "medium" | "large";
   radius: BorderRadiusConfig;
@@ -17,4 +19,5 @@ export type DropdownConfig = {
   chipColor: ChipProps["color"];
   chipSpacing: BentoSprinkles["gap"];
   openMenuOnFocus: boolean;
+  multiSelectSearchMode: MultiSelectSearchMode;
 };

--- a/packages/bento-design-system/src/SelectField/types.ts
+++ b/packages/bento-design-system/src/SelectField/types.ts
@@ -1,6 +1,7 @@
 import { ListItemProps, ListSize } from "..";
 import { LocalizedString } from "../util/LocalizedString";
 import { Omit } from "../util/Omit";
+import { MultiSelectSearchMode } from "./Config";
 
 export type SelectOption<A> = Omit<
   ListItemProps,
@@ -16,6 +17,7 @@ export type BaseSingleProps = {
 
 export type BaseMultiProps = {
   isMulti: true;
+  multiSelectSearchMode?: MultiSelectSearchMode;
   showMultiSelectBulkActions?: boolean;
   selectAllButtonLabel?: LocalizedString;
   clearAllButtonLabel?: LocalizedString;

--- a/packages/bento-design-system/src/util/defaultConfigs.tsx
+++ b/packages/bento-design-system/src/util/defaultConfigs.tsx
@@ -502,6 +502,7 @@ export const dropdown: DropdownConfig = {
   chipColor: "indigo",
   chipSpacing: 4,
   openMenuOnFocus: true,
+  multiSelectSearchMode: "clear-on-select",
 };
 
 export const table: TableConfig = {

--- a/packages/bento-design-system/stories/Components/AsyncSelectField.stories.tsx
+++ b/packages/bento-design-system/stories/Components/AsyncSelectField.stories.tsx
@@ -122,6 +122,35 @@ export const MultiSelectMultipleOptionsSelected = {
   },
 } satisfies Story;
 
+export const MultiSelectPreserveSearch = {
+  args: {
+    value: [],
+    isMulti: true,
+  },
+  render: (args) => {
+    const [value, onChange] = useState<number[]>([]);
+    return (
+      <AsyncSelectField
+        isMulti
+        label="Colors"
+        placeholder="Select colors"
+        options={args.options as SelectOption<number>[]}
+        value={value}
+        onChange={onChange}
+        loadOptions={args.loadOptions}
+        multiSelectSearchMode="preserve-on-select"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Async multi-selects can preserve the active query and reuse its loaded results.",
+      },
+    },
+  },
+} satisfies Story;
+
 const manyColors = [
   "red",
   "green",

--- a/packages/bento-design-system/stories/Components/SelectField.stories.tsx
+++ b/packages/bento-design-system/stories/Components/SelectField.stories.tsx
@@ -110,6 +110,75 @@ export const MultiSelectMultipleOptionsSelected = {
   },
 } satisfies Story;
 
+function SearchModeMultiSelect({
+  multiSelectSearchMode,
+}: {
+  multiSelectSearchMode?: "clear-on-select" | "preserve-on-select";
+}) {
+  const [value, onChange] = useState<number[]>([]);
+
+  return (
+    <SelectField
+      isMulti
+      label="Colors"
+      placeholder="Select colors"
+      options={[
+        { value: 1, label: "Red" },
+        { value: 2, label: "Green" },
+        { value: 3, label: "Blue" },
+      ]}
+      value={value}
+      onChange={onChange}
+      multiSelectSearchMode={multiSelectSearchMode}
+    />
+  );
+}
+
+export const MultiSelectPreserveSearchFromConfig = {
+  args: {
+    value: [],
+    isMulti: true,
+  },
+  render: () => <SearchModeMultiSelect />,
+  decorators: [
+    (Story: StoryFn) => (
+      <BentoConfigProvider value={{ dropdown: { multiSelectSearchMode: "preserve-on-select" } }}>
+        <Story />
+      </BentoConfigProvider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The dropdown configuration can preserve a searchable multi-select query for consecutive selections.",
+      },
+    },
+  },
+} satisfies Story;
+
+export const MultiSelectClearSearchOverride = {
+  args: {
+    value: [],
+    isMulti: true,
+  },
+  render: () => <SearchModeMultiSelect multiSelectSearchMode="clear-on-select" />,
+  decorators: [
+    (Story: StoryFn) => (
+      <BentoConfigProvider value={{ dropdown: { multiSelectSearchMode: "preserve-on-select" } }}>
+        <Story />
+      </BentoConfigProvider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story: "The component prop overrides the configured multi-select search mode.",
+      },
+    },
+  },
+} satisfies Story;
+
 const manyColors = [
   "red",
   "green",

--- a/packages/bento-design-system/test/SelectField.test.tsx
+++ b/packages/bento-design-system/test/SelectField.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import {
-  AsyncSelectField,
   BentoProvider,
   PartialBentoConfig,
   SelectField,
@@ -19,13 +18,7 @@ const options: Array<SelectOption<string>> = [
   { value: "blue", label: unsafeLocalizedString("Blue") },
 ];
 
-function MultiSelect({
-  multiSelectSearchMode,
-  searchable,
-}: {
-  multiSelectSearchMode?: MultiSelectSearchMode;
-  searchable?: boolean;
-}) {
+function MultiSelect({ multiSelectSearchMode }: { multiSelectSearchMode?: MultiSelectSearchMode }) {
   const [value, setValue] = useState<string[]>([]);
 
   return (
@@ -35,41 +28,7 @@ function MultiSelect({
       options={options}
       value={value}
       onChange={setValue}
-      searchable={searchable}
       multiSelectSearchMode={multiSelectSearchMode}
-    />
-  );
-}
-
-function AsyncMultiSelect({
-  loadOptions,
-}: {
-  loadOptions: (inputValue: string) => Promise<Array<SelectOption<string>>>;
-}) {
-  const [value, setValue] = useState<string[]>([]);
-
-  return (
-    <AsyncSelectField
-      isMulti
-      label={unsafeLocalizedString("Colors")}
-      options={options}
-      value={value}
-      onChange={setValue}
-      loadOptions={loadOptions}
-      multiSelectSearchMode="preserve-on-select"
-    />
-  );
-}
-
-function SingleSelect() {
-  const [value, setValue] = useState<string>();
-
-  return (
-    <SelectField
-      label={unsafeLocalizedString("Color")}
-      options={options}
-      value={value}
-      onChange={setValue}
     />
   );
 }
@@ -197,50 +156,5 @@ describe("SelectField multi-select search mode", () => {
     unmount();
     renderWithConfig(<MultiSelect multiSelectSearchMode="preserve-on-select" />);
     expect(screen.getByRole("combobox", { name: "Colors" })).toHaveValue("");
-  });
-
-  test("does not change single-select behavior when configured globally", async () => {
-    const user = userEvent.setup();
-    renderWithConfig(<SingleSelect />, "preserve-on-select");
-
-    const input = screen.getByRole("combobox", { name: "Color" });
-    await user.type(input, "re");
-    await user.click(screen.getByText("Red"));
-
-    expect(input).toHaveValue("");
-  });
-
-  test("does not activate for a non-searchable multi-select", () => {
-    renderWithConfig(<MultiSelect searchable={false} multiSelectSearchMode="preserve-on-select" />);
-
-    expect(screen.getByRole("combobox", { name: "Colors" })).toHaveAttribute(
-      "aria-readonly",
-      "true"
-    );
-  });
-
-  test("reuses async results when preserving the query after selection", async () => {
-    const user = userEvent.setup();
-    const loadOptions = vi.fn(async (inputValue: string) =>
-      options.filter((option) =>
-        option.label?.toString().toLowerCase().includes(inputValue.toLowerCase())
-      )
-    );
-    renderWithConfig(<AsyncMultiSelect loadOptions={loadOptions} />);
-
-    const input = screen.getByRole("combobox", { name: "Colors" });
-    await user.type(input, "re");
-    await screen.findByText("Red");
-
-    const callsForRetainedQuery = () =>
-      loadOptions.mock.calls.filter(([inputValue]) => inputValue === "re").length;
-    expect(callsForRetainedQuery()).toBe(1);
-
-    await user.click(screen.getByText("Red"));
-
-    expect(input).toHaveValue("re");
-    expect(screen.getByText("Green")).toBeVisible();
-    await waitFor(() => expect(callsForRetainedQuery()).toBe(1));
-    expect(loadOptions).not.toHaveBeenCalledWith("");
   });
 });

--- a/packages/bento-design-system/test/SelectField.test.tsx
+++ b/packages/bento-design-system/test/SelectField.test.tsx
@@ -1,0 +1,246 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import {
+  AsyncSelectField,
+  BentoProvider,
+  PartialBentoConfig,
+  SelectField,
+  SelectOption,
+  unsafeLocalizedString,
+} from "../src";
+import { defaultMessages } from "../src/defaultMessages/en";
+
+type MultiSelectSearchMode = "clear-on-select" | "preserve-on-select";
+
+const options: Array<SelectOption<string>> = [
+  { value: "red", label: unsafeLocalizedString("Red") },
+  { value: "green", label: unsafeLocalizedString("Green") },
+  { value: "blue", label: unsafeLocalizedString("Blue") },
+];
+
+function MultiSelect({
+  multiSelectSearchMode,
+  searchable,
+}: {
+  multiSelectSearchMode?: MultiSelectSearchMode;
+  searchable?: boolean;
+}) {
+  const [value, setValue] = useState<string[]>([]);
+
+  return (
+    <SelectField
+      isMulti
+      label={unsafeLocalizedString("Colors")}
+      options={options}
+      value={value}
+      onChange={setValue}
+      searchable={searchable}
+      multiSelectSearchMode={multiSelectSearchMode}
+    />
+  );
+}
+
+function AsyncMultiSelect({
+  loadOptions,
+}: {
+  loadOptions: (inputValue: string) => Promise<Array<SelectOption<string>>>;
+}) {
+  const [value, setValue] = useState<string[]>([]);
+
+  return (
+    <AsyncSelectField
+      isMulti
+      label={unsafeLocalizedString("Colors")}
+      options={options}
+      value={value}
+      onChange={setValue}
+      loadOptions={loadOptions}
+      multiSelectSearchMode="preserve-on-select"
+    />
+  );
+}
+
+function SingleSelect() {
+  const [value, setValue] = useState<string>();
+
+  return (
+    <SelectField
+      label={unsafeLocalizedString("Color")}
+      options={options}
+      value={value}
+      onChange={setValue}
+    />
+  );
+}
+
+function renderWithConfig(
+  component: React.ReactNode,
+  multiSelectSearchMode?: MultiSelectSearchMode
+) {
+  const config: PartialBentoConfig | undefined = multiSelectSearchMode
+    ? { dropdown: { multiSelectSearchMode } }
+    : undefined;
+
+  return render(
+    <BentoProvider defaultMessages={defaultMessages} config={config}>
+      {component}
+    </BentoProvider>
+  );
+}
+
+describe("SelectField multi-select search mode", () => {
+  test.each<{
+    name: string;
+    configuredMode?: MultiSelectSearchMode;
+    propMode?: MultiSelectSearchMode;
+    expectedQuery: string;
+  }>([
+    {
+      name: "clears by default",
+      expectedQuery: "",
+    },
+    {
+      name: "can preserve through the component prop",
+      propMode: "preserve-on-select",
+      expectedQuery: "re",
+    },
+    {
+      name: "can preserve through the provider config",
+      configuredMode: "preserve-on-select",
+      expectedQuery: "re",
+    },
+    {
+      name: "lets the component prop override the provider config",
+      configuredMode: "preserve-on-select",
+      propMode: "clear-on-select",
+      expectedQuery: "",
+    },
+  ])("$name", async ({ configuredMode, propMode, expectedQuery }) => {
+    const user = userEvent.setup();
+    renderWithConfig(<MultiSelect multiSelectSearchMode={propMode} />, configuredMode);
+
+    const input = screen.getByRole("combobox", { name: "Colors" });
+    await user.type(input, "re");
+    await user.click(screen.getByText("Red"));
+
+    expect(input).toHaveValue(expectedQuery);
+  });
+
+  test("keeps the filtered menu focused for consecutive pointer selections", async () => {
+    const user = userEvent.setup();
+    renderWithConfig(<MultiSelect multiSelectSearchMode="preserve-on-select" />);
+
+    const input = screen.getByRole("combobox", { name: "Colors" });
+    await user.type(input, "re");
+    await user.click(screen.getByText("Red"));
+
+    expect(input).toHaveValue("re");
+    expect(input).toHaveFocus();
+    expect(screen.getByRole("list")).toBeVisible();
+    expect(screen.queryByText("Blue")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Green"));
+
+    expect(input).toHaveValue("re");
+    expect(screen.getByText("2 options selected")).toBeVisible();
+  });
+
+  test("keeps the query during consecutive keyboard selections", async () => {
+    const user = userEvent.setup();
+    renderWithConfig(<MultiSelect multiSelectSearchMode="preserve-on-select" />);
+
+    const input = screen.getByRole("combobox", { name: "Colors" });
+    await user.type(input, "re");
+    await user.keyboard("{Enter}");
+
+    expect(input).toHaveValue("re");
+
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(input).toHaveValue("re");
+    expect(screen.getByText("2 options selected")).toBeVisible();
+  });
+
+  test("allows editing and explicitly clearing a preserved query", async () => {
+    const user = userEvent.setup();
+    renderWithConfig(<MultiSelect multiSelectSearchMode="preserve-on-select" />);
+
+    const input = screen.getByRole("combobox", { name: "Colors" });
+    await user.type(input, "re");
+    await user.click(screen.getByText("Red"));
+    await user.keyboard("{Backspace}");
+    expect(input).toHaveValue("r");
+
+    await user.clear(input);
+    expect(input).toHaveValue("");
+  });
+
+  test("clears the query on Escape, blur, and remount", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderWithConfig(
+      <>
+        <MultiSelect multiSelectSearchMode="preserve-on-select" />
+        <button>Outside</button>
+      </>
+    );
+
+    const input = screen.getByRole("combobox", { name: "Colors" });
+    await user.type(input, "re");
+    await user.keyboard("{Escape}");
+    expect(input).toHaveValue("");
+
+    await user.type(input, "bl");
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+    expect(input).toHaveValue("");
+
+    unmount();
+    renderWithConfig(<MultiSelect multiSelectSearchMode="preserve-on-select" />);
+    expect(screen.getByRole("combobox", { name: "Colors" })).toHaveValue("");
+  });
+
+  test("does not change single-select behavior when configured globally", async () => {
+    const user = userEvent.setup();
+    renderWithConfig(<SingleSelect />, "preserve-on-select");
+
+    const input = screen.getByRole("combobox", { name: "Color" });
+    await user.type(input, "re");
+    await user.click(screen.getByText("Red"));
+
+    expect(input).toHaveValue("");
+  });
+
+  test("does not activate for a non-searchable multi-select", () => {
+    renderWithConfig(<MultiSelect searchable={false} multiSelectSearchMode="preserve-on-select" />);
+
+    expect(screen.getByRole("combobox", { name: "Colors" })).toHaveAttribute(
+      "aria-readonly",
+      "true"
+    );
+  });
+
+  test("reuses async results when preserving the query after selection", async () => {
+    const user = userEvent.setup();
+    const loadOptions = vi.fn(async (inputValue: string) =>
+      options.filter((option) =>
+        option.label?.toString().toLowerCase().includes(inputValue.toLowerCase())
+      )
+    );
+    renderWithConfig(<AsyncMultiSelect loadOptions={loadOptions} />);
+
+    const input = screen.getByRole("combobox", { name: "Colors" });
+    await user.type(input, "re");
+    await screen.findByText("Red");
+
+    const callsForRetainedQuery = () =>
+      loadOptions.mock.calls.filter(([inputValue]) => inputValue === "re").length;
+    expect(callsForRetainedQuery()).toBe(1);
+
+    await user.click(screen.getByText("Red"));
+
+    expect(input).toHaveValue("re");
+    expect(screen.getByText("Green")).toBeVisible();
+    await waitFor(() => expect(callsForRetainedQuery()).toBe(1));
+    expect(loadOptions).not.toHaveBeenCalledWith("");
+  });
+});


### PR DESCRIPTION
## What changed

- Add `dropdown.multiSelectSearchMode` with `clear-on-select` and `preserve-on-select` modes.
- Add an optional multi-select component prop that overrides the configured mode.
- Preserve searchable multi-select queries after selection while still clearing on Escape, menu close, genuine blur, and remount.
- Share the behavior between synchronous and asynchronous selects, reusing async results for a retained query.
- Add generic Storybook examples and focused interaction coverage.

## Why

Searchable multi-selects sometimes need to support consecutive selections from the same filtered result set. This adds that interaction as an opt-in mode while keeping the existing clear-on-select behavior as the default.
Discussed briefly with Livia in terms of behavior / UX and she seems to agree with this addition.

## Impact

Existing consumers are unchanged. The mode applies only to interactive searchable multi-selects; single-select and non-searchable components retain their current behavior. A component prop can opt in or override the provider-level default.

## Validation

- `pnpm prettier-check`
- `pnpm eslint-check`
- `pnpm check-circular-deps`
- `pnpm typecheck`
- `pnpm --filter @buildo/bento-design-system test -- --run` — 23 tests passed
- `pnpm build`
- `pnpm --filter @buildo/bento-design-system build-storybook`

## Human review

Tested via storybook (see added stories) and it is working as expected. Considering it is an optional config and the default stays the previous behavior, this should be safe to merge